### PR TITLE
WL-2633 Bug with New Previous courses

### DIFF
--- a/tool/src/main/webapp/static/search.jsp
+++ b/tool/src/main/webapp/static/search.jsp
@@ -117,7 +117,7 @@ if (UserDirectoryService.getAnonymousUser().equals(UserDirectoryService.getCurre
 						}
 					});
 					var range = "UPCOMING";
-					if (previous == "Old Courses") {
+					if (previous.indexOf("Old Courses") >= 0) {
 						range = "PREVIOUS";
 					}
 					Signup.course.show(courseDetails, id, range, externalUser, function(){


### PR DESCRIPTION
previous is now the string representation of an array so previous == "Old Courses" doesn't work when previous is 'Old Courses:New Courses'.
