### PR TITLE
WL-2355 Fix so that with a clean repo build works.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,14 @@
 	<version>1.0-SNAPSHOT</version>
 
 	<modules>
+		<!-- license is first as mvn 2.0.x doesn't correctly identify it as being the first module
+		      that needs to be built. mvn 3 does get it correct so can be removed when we upgrade -->
+		<module>license</module>
 		<module>api</module>
 		<module>hbm</module>
 		<module>help</module>
 		<module>impl</module>
 		<module>ldap</module>
-		<module>license</module>
 		<module>pack</module>
 		<module>tool</module>
 	</modules>


### PR DESCRIPTION
Maven 2 doesn't correctly get the order of the build right and doesn't spot out plugin depenendency is available in the reactor. The order is consulted when everything else is equal so moving it first fixes the issue.
Maven 3 doesn't have this issue so it's not required once we upgrade.
