### PR TITLE
WL-2868 Keep the plugin dependency in sync.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
 						<dependency>
 							<groupId>uk.ac.ox.oucs</groupId>
 							<artifactId>course-signup-license</artifactId>
-							<version>1.0-SNAPSHOT</version>
+							<version>${project.version}</version>
 						</dependency>
 					</dependencies>
 				</plugin>


### PR DESCRIPTION
If we're going to use ${project.version} then we should everywhere.
