### PR TITLE
WL-2904 Fix for writing out the wrong value.

### DIFF
--- a/tool/src/main/java/uk/ac/ox/oucs/vle/PDFWriter.java
+++ b/tool/src/main/java/uk/ac/ox/oucs/vle/PDFWriter.java
@@ -188,7 +188,7 @@ public class PDFWriter {
 			if (otherDetails.length() > 0) {
 				otherDetails.append(" ");
 			}
-			otherDetails.append(webauthId);
+			otherDetails.append(department);
 		}
 		phrase.add(new Chunk(otherDetails.toString(), tableOtherFont));
 


### PR DESCRIPTION
We were writing out the username twice rather than the department the second time.
