### PR TITLE
WL-2372 Duplicate detection failed when no userId.

### DIFF
--- a/impl/src/main/java/uk/ac/ox/oucs/vle/CourseSignupServiceImpl.java
+++ b/impl/src/main/java/uk/ac/ox/oucs/vle/CourseSignupServiceImpl.java
@@ -737,7 +737,7 @@ public class CourseSignupServiceImpl implements CourseSignupService {
 		for (CourseComponentDAO componentDao: componentDaos) {
 			List<CourseSignupDAO> signupsToRemove = new ArrayList<CourseSignupDAO>();
 			for(CourseSignupDAO componentSignupDao: componentDao.getSignups()) {
-				if (componentSignupDao.getUserId().equals(userId)) {
+				if (componentSignupDao.getUserId().equals(user.getId())) {
 					signupsToRemove.add(componentSignupDao);
 				}
 			}


### PR DESCRIPTION
When the userId wasn't passed in (e.g. creating an external signup) the duplicate detection was using a null userId which never matched and so allowed the user to create duplicate signups for the same user.
