### PR TITLE
WL-3133 Use teachingDetails instead of slot.

### DIFF
--- a/tool/src/main/webapp/static/advance.jsp
+++ b/tool/src/main/webapp/static/advance.jsp
@@ -81,7 +81,7 @@
 					) <br />
 					<c:forEach var="component" items="${it.signup.components}">
 							&nbsp;- <c:out value="${component.title}" />
-							: <c:out value="${component.slot}" /> 
+							: <c:out value="${component.teachingDetails}" />
 							for <c:out value="${component.sessions}" /> 
 							starts in <c:out value="${component.when}" />
 						<c:if test="${not empty component.presenter.name}">

--- a/tool/src/main/webapp/static/ok.jsp
+++ b/tool/src/main/webapp/static/ok.jsp
@@ -94,7 +94,7 @@
 			) <br />
 			<c:forEach var="component" items="${it.signup.components}">
 					&nbsp;- <c:out value="${component.title}" />
-					: <c:out value="${component.slot}" /> 
+					: <c:out value="${component.teachingDetails}" />
 					for <c:out value="${component.sessions}" /> 
 					starts in <c:out value="${component.when}" />
 				<c:if test="${not empty component.presenter.name}">


### PR DESCRIPTION
When we got rid of slot there were some places in the JSPs that still referred to it and these didn't get caught by the refactoring. The pages would fall over with a stack trace.
