### PR TITLE
WL-3153 Switch to using calendar year. (bug fix)

### DIFF
--- a/impl/src/main/java/uk/ac/ox/oucs/vle/TermCode.java
+++ b/impl/src/main/java/uk/ac/ox/oucs/vle/TermCode.java
@@ -5,6 +5,7 @@ import java.util.regex.Pattern;
 
 /**
  * Represents a parsed term code.
+ * The year in an un-parsed termcode is the calendar year and not the academic year.
  *
  * @author Matthew Buckett
  */
@@ -18,7 +19,7 @@ class TermCode implements Comparable<TermCode> {
 	 */
 	public static enum Terms {
 		// Order matters as it's used for sorting.
-		MT("Michaelmas"), HT("Hilary"),TT("Trinity");
+		HT("Hilary"),TT("Trinity"), MT("Michaelmas");
 
 		private String title;
 
@@ -60,7 +61,7 @@ class TermCode implements Comparable<TermCode> {
 	 */
 	public String getName() {
 		if (isValid()) {
-			return String.format("%s %d/%d", term.title(), 2000+year, year+1);
+			return String.format("%s %d", term.title(), 2000+year);
 		}
 		return null;
 	}

--- a/impl/src/test/java/uk/ac/ox/oucs/vle/NoDateComparatorTest.java
+++ b/impl/src/test/java/uk/ac/ox/oucs/vle/NoDateComparatorTest.java
@@ -37,8 +37,8 @@ public class NoDateComparatorTest {
 
 	@Test
 	public void testDiffTerm() {
-		CourseGroup cg1 = newGroup("HT11", CG1);
-		CourseGroup cg2 = newGroup("MT11", CG2);
+		CourseGroup cg1 = newGroup("MT11", CG1);
+		CourseGroup cg2 = newGroup("HT11", CG2);
 		assertSymmetric(cg1, cg2);
 	}
 
@@ -66,17 +66,17 @@ public class NoDateComparatorTest {
 	@Test
 	public void testCollectionSort() {
 
-		CourseGroup cg0 = newGroup(null, "0");
-		CourseGroup cg1 = newGroup("TT13", "1");
-		CourseGroup cg2 = newGroup("TT12", "2");
-		CourseGroup cg3 = newGroup("TT11", "3");
-		CourseGroup cg4 = newGroup("HT11", "4");
-		CourseGroup cg5 = newGroup("MT11", "5");
+		CourseGroup aNull = newGroup(null, "0");
+		CourseGroup tt13 = newGroup("TT13", "1");
+		CourseGroup tt12 = newGroup("TT12", "2");
+		CourseGroup tt11 = newGroup("TT11", "3");
+		CourseGroup ht11 = newGroup("HT11", "4");
+		CourseGroup mt11 = newGroup("MT11", "5");
 
-		List<CourseGroup> list = Arrays.asList(cg0, cg1, cg2, cg3, cg4, cg5);
+		List<CourseGroup> list = Arrays.asList(aNull, tt13, tt12, tt11, ht11, mt11);
 		Collections.shuffle(list);
 		Collections.sort(list, comp);
-		assertArrayEquals(new CourseGroup[]{cg5, cg4, cg3, cg2, cg1, cg0}, list.toArray());
+		assertArrayEquals(new CourseGroup[]{ht11, tt11, mt11, tt12, tt13, aNull}, list.toArray());
 	}
 
 	private void assertSymmetric(CourseGroup cg1, CourseGroup cg2) {

--- a/impl/src/test/java/uk/ac/ox/oucs/vle/TermCodeTest.java
+++ b/impl/src/test/java/uk/ac/ox/oucs/vle/TermCodeTest.java
@@ -1,0 +1,49 @@
+package uk.ac.ox.oucs.vle;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @see NoDateComparator For other tests.
+ */
+public class TermCodeTest {
+
+	@Test
+	public void testGetName() {
+		TermCode termCode = new TermCode("TT10");
+		assertEquals("Trinity 2010", termCode.getName());
+	}
+
+	@Test
+	public void testTermOrder() {
+		// These are academic years.
+		TermCode ht10 = new TermCode("HT10");
+		TermCode tt10 = new TermCode("TT10");
+		TermCode mt10 = new TermCode("MT10");
+		// ht before mt
+		symmetricCompare(ht10, mt10);
+		// tt berfore mt
+		symmetricCompare(tt10, mt10);
+		// ht before tt
+		symmetricCompare(ht10, tt10);
+	}
+
+	@Test
+	public void testYearOrder() {
+		TermCode ht10 = new TermCode("HT10");
+		TermCode ht11 = new TermCode("HT11");
+		TermCode mt12 = new TermCode("MT12");
+
+		symmetricCompare(ht10, ht11);
+		symmetricCompare(ht10, mt12);
+		symmetricCompare(ht11, mt12);
+	}
+
+	private void symmetricCompare(TermCode first, TermCode second) {
+		assertTrue(first.compareTo(second) < 0);
+		assertTrue(second.compareTo(first) > 0);
+	}
+
+}


### PR DESCRIPTION
Previously the code wrongly assumed that the term code referred to the academic year when this is not the case. The update switches to treating it as the calendar year.

This means the sorting of terms changes.
