### PR TITLE
WL-3335 Don’t fail on reading category mappings.

### DIFF
--- a/impl/src/main/resources/sakai-beans.xml
+++ b/impl/src/main/resources/sakai-beans.xml
@@ -43,6 +43,7 @@
 		<property name="serverConfigurationService" ref="org.sakaiproject.component.api.ServerConfigurationService"/>
 		<property name="contentHostingService" ref="org.sakaiproject.content.api.ContentHostingService"/>
 		<property name="sessionManager" ref="org.sakaiproject.tool.api.SessionManager"/>
+		<property name="securityService" ref="org.sakaiproject.authz.api.SecurityService"/>
 	</bean>
 
 	<bean id="uk.ac.ox.oucs.vle.DaisyPopulatorJobWrapper"


### PR DESCRIPTION
If the category mappings file isn’t publicly readable we would log a big stack trace. As this file doesn’t need to be publicly readable we should just use an advisor to always allow access to it.
