### PR TITLE
WL-3830 Make flushes happen sooner to stop losing data.

### DIFF
--- a/impl/src/main/java/uk/ac/ox/oucs/vle/CourseDAO.java
+++ b/impl/src/main/java/uk/ac/ox/oucs/vle/CourseDAO.java
@@ -149,4 +149,11 @@ public interface CourseDAO {
 	
 	void save(CourseCategoryDAO category);
 
+	/**
+	 * This was created to allow the importers to flush to the DB more quickly as we were seeing
+	 * issues where some collections where getting lose and not flushed to the DB.
+	 * @param i The flushmode.
+	 */
+	void setFlushMode(int i);
+
 }

--- a/impl/src/main/java/uk/ac/ox/oucs/vle/CourseDAOImpl.java
+++ b/impl/src/main/java/uk/ac/ox/oucs/vle/CourseDAOImpl.java
@@ -973,6 +973,10 @@ public class CourseDAOImpl extends HibernateDaoSupport implements CourseDAO {
 
 	}
 
+	public void setFlushMode(int i) {
+		getHibernateTemplate().setFlushMode(i);
+	}
+
 }
 
 

--- a/impl/src/main/java/uk/ac/ox/oucs/vle/XcriOxCapPopulatorImpl.java
+++ b/impl/src/main/java/uk/ac/ox/oucs/vle/XcriOxCapPopulatorImpl.java
@@ -30,10 +30,12 @@ import java.util.regex.Pattern;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.hibernate.FlushMode;
 import org.jdom2.Document;
 import org.jdom2.JDOMException;
 import org.jdom2.input.SAXBuilder;
 import org.sakaiproject.util.FormattedText;
+import org.springframework.orm.hibernate3.HibernateAccessor;
 import org.xcri.Extension;
 import org.xcri.common.ExtensionManager;
 import org.xcri.common.OverrideManager;
@@ -143,6 +145,9 @@ public class XcriOxCapPopulatorImpl implements Populator {
 		InputStream input = null;
 		
 		try {
+			// This is so that collections don't get lost, this is a hack but I couldn't find the
+			// simple fix to get it working.
+			dao.setFlushMode(HibernateAccessor.FLUSH_EAGER);
 			input = populatorInput.getInput(context);
 
 			if (null == input) {
@@ -856,12 +861,15 @@ public class XcriOxCapPopulatorImpl implements Populator {
 			groupDao.setSupervisorApproval(myCourse.getSupervisorApproval());
 			groupDao.setAdministratorApproval(myCourse.getAdministratorApproval());
 			groupDao.setContactEmail(myCourse.getContactEmail());
-			groupDao.setAdministrators(myCourse.getAdministrators());
+			groupDao.getAdministrators().clear();
+			groupDao.getAdministrators().addAll(myCourse.getAdministrators());
 			groupDao.setPrerequisite(myCourse.getPrerequisite());
 			groupDao.setRegulations(myCourse.getRegulations());
 			groupDao.setDeleted(false);
-			groupDao.setSuperusers(myCourse.getSuperusers());
-			groupDao.setOtherDepartments(myCourse.getOtherDepartments());
+			groupDao.getSuperusers().clear();
+			groupDao.getSuperusers().addAll(myCourse.getSuperusers());
+			groupDao.getOtherDepartments().clear();
+			groupDao.getOtherDepartments().addAll(myCourse.getOtherDepartments());
 
 			dao.save(groupDao);
 		}

--- a/impl/src/main/resources/course-signup-beans.xml
+++ b/impl/src/main/resources/course-signup-beans.xml
@@ -107,7 +107,7 @@
 		<property name="transactionManager" ref="org.sakaiproject.springframework.orm.hibernate.GlobalTransactionManager" />
 		<property name="transactionAttributes">
 			<value>
-				update=PROPAGATION_REQUIRED
+				runPopulator=PROPAGATION_REQUIRED
 			</value>
 		</property>
 	</bean>
@@ -132,7 +132,7 @@
 		<property name="transactionManager" ref="org.sakaiproject.springframework.orm.hibernate.GlobalTransactionManager" />
 		<property name="transactionAttributes">
 			<value>
-				update=PROPAGATION_REQUIRED
+				runPopulator=PROPAGATION_REQUIRED
 			</value>
 		</property>
 	</bean>

--- a/impl/src/test/java/uk/ac/ox/oucs/vle/TestCourseDAO.java
+++ b/impl/src/test/java/uk/ac/ox/oucs/vle/TestCourseDAO.java
@@ -47,6 +47,40 @@ public class TestCourseDAO extends AbstractTransactionalSpringContextTests {
 		return new String[]{"/course-dao.xml", "/test-with-h2.xml"};
 	}
 
+	public void testUpdatingAdministrators() {
+		CourseGroupDAO dao;
+		dao = courseDao.newCourseGroup("id", "Title", "Department", "Subunit");
+		dao.setSource("source");
+		dao.getAdministrators().clear();
+		dao.getAdministrators().add("1234");
+		dao.getAdministrators().add("5678");
+		courseDao.save(dao);
+
+		CourseGroupDAO dao2;
+		dao2 = courseDao.newCourseGroup("id2", "Title", "Department", "Subunit");
+		dao2.setSource("source");
+		dao2.getAdministrators().clear();
+		dao2.getAdministrators().add("1234");
+		dao2.getAdministrators().add("5678");
+		courseDao.save(dao2);
+
+		courseDao.flushAndClear();
+
+		dao = courseDao.findCourseGroupById("id");
+		assertFalse(dao.getAdministrators().isEmpty());
+
+		dao2 = courseDao.findCourseGroupById("id2");
+		dao2.getAdministrators().clear();
+		dao2.getAdministrators().add("abcd");
+		courseDao.save(dao2);
+
+		courseDao.flushAndClear();
+
+		dao2 = courseDao.findCourseGroupById("id2");
+
+		assertFalse(dao2.getAdministrators().isEmpty());
+
+	}
 
 	/**
 	 * This checks that when you delete a component without a signup only that component gets deleted.


### PR DESCRIPTION
We have been seeing problems where the collections of Strings have been lost when the importer is running. It seems to be related to how the production code uses transactions as I was unable to reproduce this in a test.

Due to having spend too much time on this already the simple fix is to just get the code to write through the DB early which seems to fix it issue.

This might also fix the problems with having multiple importers running concurrently against a clean DB, but I haven’t checked this.