### PR TITLE
WL-3844 Correctly shutdown basic authed sessions.

### DIFF
--- a/tool/src/main/webapp/WEB-INF/web.xml
+++ b/tool/src/main/webapp/WEB-INF/web.xml
@@ -92,6 +92,14 @@
 		<dispatcher>FORWARD</dispatcher>
 		<dispatcher>INCLUDE</dispatcher>
 	</filter-mapping>
+
+	<filter-mapping>
+		<filter-name>sakai.request</filter-name>
+		<servlet-name>Jersey Web BasicAuth Application</servlet-name>
+		<dispatcher>REQUEST</dispatcher>
+		<dispatcher>FORWARD</dispatcher>
+		<dispatcher>INCLUDE</dispatcher>
+	</filter-mapping>
 	<!--  
 	<filter-mapping>
 		<filter-name>require.authentication</filter-name>


### PR DESCRIPTION
When someone uses basic auth to access the RTT tool (normally only TMS), the session is setup so that it doesn’t persist across requests, but this also means it doesn’t get cleaned up correctly as it’s not in the pool of sessions that get invalidated. This fix makes sure that we use the standard request filter on all requests so that the session is one that persists and this also means threadlocals are managed correctly.

We also manually invalidate the session at the end of the request as when doing basic auth the session won’t get used again.