### PR TITLE
WL-3019 Set all responses to be UTF-8

### DIFF
--- a/tool/src/main/java/uk/ac/ox/oucs/vle/CharsetResponseFilter.java
+++ b/tool/src/main/java/uk/ac/ox/oucs/vle/CharsetResponseFilter.java
@@ -1,0 +1,38 @@
+package uk.ac.ox.oucs.vle;
+
+import com.sun.jersey.spi.container.ContainerRequest;
+import com.sun.jersey.spi.container.ContainerResponse;
+import com.sun.jersey.spi.container.ContainerResponseFilter;
+
+import javax.ws.rs.core.MediaType;
+
+/**
+ * This sets a character set on responses.
+ */
+public class CharsetResponseFilter implements ContainerResponseFilter {
+
+    public static final String CHARSET = "charset=";
+    private final String charset;
+
+    public CharsetResponseFilter() {
+        this.charset = "UTF-8";
+    }
+
+    public CharsetResponseFilter(String charset) {
+        this.charset = charset;
+    }
+
+    @Override
+    public ContainerResponse filter(ContainerRequest request, ContainerResponse response) {
+
+        MediaType contentType = response.getMediaType();
+        if(contentType != null) {
+            String value = contentType.toString();
+            if (!value.contains(CHARSET)) {
+                response.getHttpHeaders().putSingle("Content-Type", value + ";" + CHARSET + charset);
+            }
+        }
+
+        return response;
+    }
+}

--- a/tool/src/main/java/uk/ac/ox/oucs/vle/resources/CourseResource.java
+++ b/tool/src/main/java/uk/ac/ox/oucs/vle/resources/CourseResource.java
@@ -90,7 +90,7 @@ public class CourseResource {
 	
 	@Path("/{id}")
 	@GET
-	@Produces(MediaType.APPLICATION_JSON+"; charset=UTF-8")
+	@Produces(MediaType.APPLICATION_JSON)
 	public StreamingOutput getCourse(@PathParam("id") final String courseId, @QueryParam("range") final Range range) {
 		
 		final CourseGroup course = courseService.getCourseGroup(courseId, range);
@@ -118,7 +118,7 @@ public class CourseResource {
 
 	@Path("/all")
 	@GET
-	@Produces(MediaType.APPLICATION_JSON+"; charset=UTF-8")
+	@Produces(MediaType.APPLICATION_JSON)
 	public StreamingOutput getCourses(@QueryParam("range") final Range range) {
 		boolean externalUser = false;
 		if (UserDirectoryService.getAnonymousUser().equals(UserDirectoryService.getCurrentUser())) {

--- a/tool/src/main/webapp/WEB-INF/web.xml
+++ b/tool/src/main/webapp/WEB-INF/web.xml
@@ -160,6 +160,10 @@
 			<param-name>com.sun.jersey.config.property.packages</param-name>
 			<param-value>uk.ac.ox.oucs.vle.resources;org.codehaus.jackson.jaxrs,uk.ac.ox.oucs.vle.sakai</param-value>
 		</init-param>
+		<init-param>
+			<param-name>com.sun.jersey.spi.container.ContainerResponseFilters</param-name>
+			<param-value>uk.ac.ox.oucs.vle.CharsetResponseFilter</param-value>
+		</init-param>
 		<load-on-startup>1</load-on-startup>
 	</servlet>
 	
@@ -169,6 +173,10 @@
 		<init-param>
 			<param-name>com.sun.jersey.config.property.packages</param-name>
 			<param-value>uk.ac.ox.oucs.vle,resources;org.codehaus.jackson.jaxrs,uk.ac.ox.oucs.vle.sakai</param-value>
+		</init-param>
+		<init-param>
+			<param-name>com.sun.jersey.spi.container.ContainerResponseFilters</param-name>
+			<param-value>uk.ac.ox.oucs.vle.CharsetResponseFilter</param-value>
 		</init-param>
 		<load-on-startup>1</load-on-startup>
 	</servlet>


### PR DESCRIPTION
We always store all data in UTF-8 so all responses should be in UTF-8, rather than manually making sure we set each response to be UTF-8 we just add a filter that does this. The default otherwise was ISO-8859-1.