### PR TITLE
Remove duplicate servlet that was not needed.

### DIFF
--- a/tool/src/main/webapp/WEB-INF/web.xml
+++ b/tool/src/main/webapp/WEB-INF/web.xml
@@ -25,15 +25,15 @@
                   http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd">
 	<display-name>Course Signup</display-name>
 
+	<!-- Load Spring context -->
 	<listener>
 		<listener-class>org.sakaiproject.util.ContextLoaderListener</listener-class>
 	</listener>
-	<!--
-		Use the Sakai Spring application context wrapper to reach components.
-	--> 
+	<!-- Register out tool -->
 	<listener>
 		<listener-class>org.sakaiproject.util.ToolListener</listener-class>
 	</listener>
+
 	<filter>
 		<filter-name>sakai.request</filter-name>
 		<filter-class>uk.ac.ox.oucs.vle.StreamRequestFilter</filter-class>
@@ -50,12 +50,7 @@
 			<param-value></param-value>
 		</init-param>
 	</filter>
-	<!--  
-	<filter>
-		<filter-name>require.authentication</filter-name>
-		<filter-class>uk.ac.ox.oucs.vle.AuthenticatedRequestFilter</filter-class>
-	</filter>
-	-->
+
 	<filter>
 		<filter-name>require.basicauthentication</filter-name>
 		<filter-class>uk.ac.ox.oucs.vle.BasicAuthenticatedRequestFilter</filter-class>
@@ -94,24 +89,8 @@
 	</filter-mapping>
 
 	<filter-mapping>
-		<filter-name>sakai.request</filter-name>
-		<servlet-name>Jersey Web BasicAuth Application</servlet-name>
-		<dispatcher>REQUEST</dispatcher>
-		<dispatcher>FORWARD</dispatcher>
-		<dispatcher>INCLUDE</dispatcher>
-	</filter-mapping>
-	<!--  
-	<filter-mapping>
-		<filter-name>require.authentication</filter-name>
-		<servlet-name>Jersey Web Application</servlet-name>
-		<dispatcher>REQUEST</dispatcher>
-		<dispatcher>FORWARD</dispatcher>
-		<dispatcher>INCLUDE</dispatcher>
-	</filter-mapping>
-	-->
-	<filter-mapping>
 		<filter-name>require.basicauthentication</filter-name>
-		<servlet-name>Jersey Web BasicAuth Application</servlet-name>
+		<url-pattern>/auth_rest/*</url-pattern>
 		<dispatcher>REQUEST</dispatcher>
 		<dispatcher>FORWARD</dispatcher>
 		<dispatcher>INCLUDE</dispatcher>
@@ -139,14 +118,6 @@
 	</filter-mapping>
 	
 	<filter-mapping>
-		<filter-name>hibernate-session</filter-name>
-		<servlet-name>Jersey Web BasicAuth Application</servlet-name>
-		<dispatcher>REQUEST</dispatcher>
-		<dispatcher>FORWARD</dispatcher>
-		<dispatcher>INCLUDE</dispatcher>
-	</filter-mapping>
-	
-	<filter-mapping>
         <filter-name>oauth.post</filter-name>
         <servlet-name>Jersey Web Application</servlet-name>
         <dispatcher>REQUEST</dispatcher>
@@ -167,20 +138,6 @@
 		<load-on-startup>1</load-on-startup>
 	</servlet>
 	
-	<servlet>
-		<servlet-name>Jersey Web BasicAuth Application</servlet-name>
-		<servlet-class>com.sun.jersey.spi.spring.container.servlet.SpringServlet</servlet-class>
-		<init-param>
-			<param-name>com.sun.jersey.config.property.packages</param-name>
-			<param-value>uk.ac.ox.oucs.vle,resources;org.codehaus.jackson.jaxrs,uk.ac.ox.oucs.vle.sakai</param-value>
-		</init-param>
-		<init-param>
-			<param-name>com.sun.jersey.spi.container.ContainerResponseFilters</param-name>
-			<param-value>uk.ac.ox.oucs.vle.CharsetResponseFilter</param-value>
-		</init-param>
-		<load-on-startup>1</load-on-startup>
-	</servlet>
-
 	<servlet>
 		<servlet-name>course.admin</servlet-name>
 		<servlet-class>uk.ac.ox.oucs.vle.SchedulerTool</servlet-class>
@@ -207,7 +164,7 @@
 	
 	<servlet-mapping>
 		<!--  So we can access the static content. -->
-		<servlet-name>Jersey Web BasicAuth Application</servlet-name>
+		<servlet-name>Jersey Web Application</servlet-name>
 		<url-pattern>/auth_rest/*</url-pattern>
 	</servlet-mapping>
 	


### PR DESCRIPTION
We had 2 copies of the Jersey Application starting up, this was so that one could have basic auth in front of it. However the basic auth is just done in a filter so we can mount the same servlet at 2 URLs and just put the basic auth filter in front of them.

Also removed commented out sections and added a few comments.