### PR TITLE
WL-2982 Don’t show booking ability when there is none.

### DIFF
--- a/tool/src/main/webapp/static/course.tpl
+++ b/tool/src/main/webapp/static/course.tpl
@@ -81,19 +81,15 @@
 					</tr>
 					{/if}
 
-					{if source == "Daisy"}
+					{if signup}
 					<tr>
 						<th>Signup Available</th>
 						<td>
-							{if signup}
-								{if signup == "full" || waiting}
-									Waiting List of ${waiting}
-								{else}
-									${signup} 
-								{/if}
+							{if signup == "full" || waiting}
+								Waiting List of ${waiting}
 							{else}
-								Not bookable
-							{/if}		
+								${signup}
+							{/if}
 						</td>
 					</tr>
 					{/if}


### PR DESCRIPTION
It used to be the case that all courses from the service called DAISY would be bookable, however now DAISY includes some courses that aren’t bookable and in general when we don’t know if something is bookable we hide this field.