### PR TITLE
WL-4029 Fix Basic Auth for export.

### DIFF
--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -15,6 +15,9 @@
 	<organization>
 		<name>University of Oxford</name>
 	</organization>
+	<properties>
+		<powermock.version>1.6.2</powermock.version>
+	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.sakaiproject.kernel</groupId>
@@ -166,8 +169,26 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>1.9.5</version>
+			<version>1.10.19</version>
 			<scope>test</scope>
+		</dependency>
+		<!-- So we can mock non-injected dependencies -->
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-module-junit4</artifactId>
+			<version>${powermock.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-api-mockito</artifactId>
+			<version>${powermock.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<!-- Needed for powermock -->
+		<dependency>
+			<groupId>commons-fileupload</groupId>
+			<artifactId>commons-fileupload</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/tool/src/main/webapp/WEB-INF/web.xml
+++ b/tool/src/main/webapp/WEB-INF/web.xml
@@ -52,7 +52,7 @@
 	</filter>
 
 	<filter>
-		<filter-name>require.basicauthentication</filter-name>
+		<filter-name>sakai.basicauth</filter-name>
 		<filter-class>uk.ac.ox.oucs.vle.BasicAuthenticatedRequestFilter</filter-class>
 	</filter>
 	
@@ -88,9 +88,10 @@
 		<dispatcher>INCLUDE</dispatcher>
 	</filter-mapping>
 
+	<!-- This has to happen after the sakai.request filter -->
 	<filter-mapping>
-		<filter-name>require.basicauthentication</filter-name>
-		<url-pattern>/auth_rest/*</url-pattern>
+		<filter-name>sakai.basicauth</filter-name>
+		<servlet-name>Jersey Web Application</servlet-name>
 		<dispatcher>REQUEST</dispatcher>
 		<dispatcher>FORWARD</dispatcher>
 		<dispatcher>INCLUDE</dispatcher>

--- a/tool/src/test/java/uk/ac/ox/oucs/vle/BasicAuthenticatedRequestFilterTest.java
+++ b/tool/src/test/java/uk/ac/ox/oucs/vle/BasicAuthenticatedRequestFilterTest.java
@@ -1,0 +1,134 @@
+package uk.ac.ox.oucs.vle;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.sakaiproject.component.cover.ComponentManager;
+import org.sakaiproject.tool.api.Session;
+import org.sakaiproject.tool.api.SessionManager;
+import org.sakaiproject.user.api.User;
+import org.sakaiproject.user.api.UserDirectoryService;
+import org.sakaiproject.util.BasicAuth;
+import org.sakaiproject.util.RequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static org.mockito.Mockito.*;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
+
+/**
+ * Test our basic auth filter.
+ */
+@RunWith(PowerMockRunner.class)
+
+@PrepareForTest( {
+        // This is so that we can mock the statics.
+        ComponentManager.class,
+        // This is so that the we can mock the new BasicAuth()
+        BasicAuthenticatedRequestFilter.class
+        })
+public class BasicAuthenticatedRequestFilterTest {
+
+    public static final String ANON_ID = "";
+    private static final String USER_ID = "userId";
+    @Mock
+    private UserDirectoryService userDirectoryService;
+
+    @Mock
+    private SessionManager sessionManager;
+
+    @Mock
+    private Session session;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private FilterChain chain;
+
+    @Mock
+    private BasicAuth basicAuth;
+
+    private BasicAuthenticatedRequestFilter filter;
+
+    @Before
+    public void setUp() throws Exception {
+        mockStatic(ComponentManager.class);
+        when(ComponentManager.get(UserDirectoryService.class)).thenReturn(userDirectoryService);
+        when(ComponentManager.get(SessionManager.class)).thenReturn(sessionManager);
+        when(sessionManager.getCurrentSession()).thenReturn(session);
+        // Mock the anonymous user
+        User anon = mock(User.class);
+        when(anon.getId()).thenReturn(ANON_ID);
+        when(userDirectoryService.getAnonymousUser()).thenReturn(anon);
+
+        whenNew(BasicAuth.class).withNoArguments().thenReturn(basicAuth);
+        filter = new BasicAuthenticatedRequestFilter();
+        filter.init(mock(FilterConfig.class));
+    }
+
+    @Test
+    public void testNormalRequest() throws IOException, ServletException {
+        when(request.getAttribute(RequestFilter.ATTR_FILTERED)).thenReturn(RequestFilter.ATTR_FILTERED);
+        when(session.getUserId()).thenReturn(ANON_ID);
+
+        filter.doFilter(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+        verify(session, never()).invalidate();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testNotFiltered() throws IOException, ServletException {
+        when(session.getUserId()).thenReturn(ANON_ID);
+        filter.doFilter(request, response, chain);
+    }
+
+    @Test
+    public void testAuthGood() throws IOException, ServletException {
+        when(request.getAttribute(RequestFilter.ATTR_FILTERED)).thenReturn(RequestFilter.ATTR_FILTERED);
+        when(session.getUserId()).thenReturn(ANON_ID).thenReturn(USER_ID);
+
+        filter.doFilter(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+        verify(basicAuth).doLogin(request);
+        verify(session).invalidate();
+    }
+
+    @Test
+    public void testAuthFailed() throws IOException, ServletException {
+        when(request.getAttribute(RequestFilter.ATTR_FILTERED)).thenReturn(RequestFilter.ATTR_FILTERED);
+        when(session.getUserId()).thenReturn(ANON_ID).thenReturn(ANON_ID);
+
+        filter.doFilter(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+        verify(basicAuth).doLogin(request);
+        verify(session, never()).invalidate();
+    }
+
+    @Test
+    public void testNoAuthAlreadyLoggedIn() throws IOException, ServletException {
+        when(request.getAttribute(RequestFilter.ATTR_FILTERED)).thenReturn(RequestFilter.ATTR_FILTERED);
+        when(session.getUserId()).thenReturn(USER_ID).thenReturn(USER_ID);
+
+        filter.doFilter(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+        verify(basicAuth).doLogin(request);
+        verify(session, never()).invalidate();
+    }
+}


### PR DESCRIPTION
Fix the handling of basic auth so that it’s checked on all requests and if it’s present it’s used and if it’s not present we just carry on. This allows simplification of servlets paths.

Basic Auth was broken because the servlet path based filter was getting applied before the servlet name based filters are and the authentication was lost because the request hadn’t been correctly setup.