### PR TITLE
WL-4101 Make course_component.presentationId unique.

### DIFF
--- a/hbm/src/main/resources/uk/ac/ox/oucs/vle/Course.hbm.xml
+++ b/hbm/src/main/resources/uk/ac/ox/oucs/vle/Course.hbm.xml
@@ -129,7 +129,8 @@
 		</id>
 		<!-- We want to be sure the taken column isn't out of sync -->
 		<version name="version" column="version"/>
-		<property name="presentationId" type="string" length="255" />
+		<property name="presentationId" type="string" length="255" unique="true"
+			index="course_component_presentationId_idx" />
 		<property name="title" type="string" length="256" />
 		<property name="termcode" type="string" length="30"
 			index="course_component_term_idx" />


### PR DESCRIPTION
This is an old primary key that should still be unique as having duplicates would cause problems.