### PR TITLE
WL-4112 Change module to course in UI/emails

### DIFF
--- a/api/src/main/java/uk/ac/ox/oucs/vle/CourseDepartment.java
+++ b/api/src/main/java/uk/ac/ox/oucs/vle/CourseDepartment.java
@@ -1,0 +1,14 @@
+package uk.ac.ox.oucs.vle;
+
+import java.util.Set;
+
+/**
+ * Details of a department that has students going on courses.
+ */
+public interface CourseDepartment {
+
+    String getCode();
+    boolean isApprovalRequired();
+    Set<String> getApprovers();
+
+}

--- a/api/src/main/java/uk/ac/ox/oucs/vle/CourseSignup.java
+++ b/api/src/main/java/uk/ac/ox/oucs/vle/CourseSignup.java
@@ -34,7 +34,7 @@ public interface CourseSignup extends java.io.Serializable{
 	
 	/**
 	 * 
-	 * @return Identity of student making the signup
+	 * @return Identity of student making the signup, can be <code>null</code> if the user can't be found.
 	 */
 	public Person getUser();
 	

--- a/api/src/main/java/uk/ac/ox/oucs/vle/CourseSignupService.java
+++ b/api/src/main/java/uk/ac/ox/oucs/vle/CourseSignupService.java
@@ -34,8 +34,8 @@ import java.util.*;
  *
  */
 public interface CourseSignupService {
-	
-	public static enum Status {
+
+	enum Status {
 		PENDING(false),
 		WITHDRAWN(false),
 		APPROVED(true),
@@ -56,6 +56,21 @@ public interface CourseSignupService {
 		
 		public int getSpacesTaken() {
 			return (takeSpace)?1:0;
+		}
+
+		/**
+		 * Utility method for checking if a status matches another set.
+		 * @param status The status being tested, can be <code>null</code>.
+		 * @param others The set of statuses to be matched against, cannot contain <code>null</code>
+		 * @return <code>true</code> if there is a match.
+		 */
+		public static boolean matches(Status status, Status... others) {
+			for (Status other: others) {
+				if (other.equals(status)) {
+					return true;
+				}
+			}
+			return false;
 		}
 	};
 	
@@ -241,5 +256,7 @@ public interface CourseSignupService {
 	public String getDirectUrl(String courseId);
 	
 	public Integer getRecentDays();
+
+	CourseDepartment findDepartmentByCode(String department);
 
 }

--- a/hbm/src/main/java/uk/ac/ox/oucs/vle/CourseDepartmentDAO.java
+++ b/hbm/src/main/java/uk/ac/ox/oucs/vle/CourseDepartmentDAO.java
@@ -22,11 +22,12 @@ package uk.ac.ox.oucs.vle;
 import java.util.HashSet;
 import java.util.Set;
 
+/**
+ * This exists so that we can see if a department wants to approve signups and if so
+ * who the approvers are.
+ */
 public class CourseDepartmentDAO implements java.io.Serializable {
 	
-	/**
-	 * 
-	 */
 	private static final long serialVersionUID = 1L;
 	private String code;
     private String name;

--- a/hbm/src/main/java/uk/ac/ox/oucs/vle/CourseUserPlacementDAO.java
+++ b/hbm/src/main/java/uk/ac/ox/oucs/vle/CourseUserPlacementDAO.java
@@ -22,18 +22,21 @@ package uk.ac.ox.oucs.vle;
 import java.util.HashSet;
 import java.util.Set;
 
+/**
+ * We store the user placement so that when a user gets a link in an email it links back to the copy of the tool
+ * that was last used. This does mean that if a placement is removed all the links sent out will be broken, so in
+ * lots of ways it would be better if there was just one "standard" URL which pointed to the one copy of the
+ * tool.
+ */
 public class CourseUserPlacementDAO implements java.io.Serializable {
-	
-	/**
-	 * 
-	 */
+
 	private static final long serialVersionUID = 1L;
 	private String userId;
     private String placementId;
     
     public CourseUserPlacementDAO() {
     }
-    
+
     public CourseUserPlacementDAO(String userId) {
     	this.userId = userId;
     }

--- a/help/src/course_signup/help.xml
+++ b/help/src/course_signup/help.xml
@@ -23,7 +23,7 @@
 			<value>ses_browsing</value>
 		</property>
 		<property name="name">
-			<value>Browsing / Searching for a Module</value>
+			<value>Browsing / Searching for a Course</value>
 		</property>
 		<property name="location">
 			<value>/course_signup/ses_browsing.html</value>
@@ -35,7 +35,7 @@
 			<value>ses_signup</value>
 		</property>
 		<property name="name">
-			<value>Signing Up for a Module</value>
+			<value>Signing Up for a Course</value>
 		</property>
 		<property name="location">
 			<value>/course_signup/ses_signup.html</value>
@@ -47,7 +47,7 @@
 			<value>ses_modulefull</value>
 		</property>
 		<property name="name">
-			<value>What to do if a Module is Full</value>
+			<value>What to do if a Course is Full</value>
 		</property>
 		<property name="location">
 			<value>/course_signup/ses_modulefull.html</value>
@@ -59,7 +59,7 @@
 			<value>ses_mystatus</value>
 		</property>
 		<property name="name">
-			<value>Checking My Status on a Module</value>
+			<value>Checking My Status on a Course</value>
 		</property>
 		<property name="location">
 			<value>/course_signup/ses_mystatus.html</value>
@@ -71,7 +71,7 @@
 			<value>ses_withdrawing</value>
 		</property>
 		<property name="name">
-			<value>Withdrawing from a Module</value>
+			<value>Withdrawing from a Course</value>
 		</property>
 		<property name="location">
 			<value>/course_signup/ses_withdrawing.html</value>
@@ -83,7 +83,7 @@
 			<value>ses_module_admin</value>
 		</property>
 		<property name="name">
-			<value>Module Administrators Guide</value>
+			<value>Course Administrators Guide</value>
 		</property>
 		<property name="location">
 			<value>/course_signup/ses_module_admin.html</value>
@@ -125,7 +125,7 @@
 							<ref bean="sesMyStatus" />
 							<ref bean="sesWithdrawing" />
 
-							<!--  For Module Admins pages -->
+							<!--  For Course Admins pages -->
 							<ref bean="sesModuleAdmin" />
 
 							<!--  Supervisor pages -->

--- a/help/src/course_signup/ses_browsing.html
+++ b/help/src/course_signup/ses_browsing.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html><head>
-<title>Browsing Modules</title>
+<title>Browsing Courses</title>
 <style type="text/css">
 </style>
 <link type="text/css" href="/library/skin/tool_base.css" media="all" rel="stylesheet" />
@@ -9,16 +9,16 @@
 <body>
 <div class="helpBody">
 
-<h2>Browsing / Searching for a Module</h2>
+<h2>Browsing / Searching for a Course</h2>
 
-<p>There are four ways to find modules. You may: <strong>Search Modules</strong>, <strong>Browse by Department</strong>, 
+<p>There are four ways to find courses. You may: <strong>Search Courses</strong>, <strong>Browse by Department</strong>,
 <strong>Browse by Calendar</strong> (date), or <strong>Search by Vitae RDF Domains and Subdomain</strong>.</p>
 
 
-<h3>Search Modules</h3>
+<h3>Search Courses</h3>
 
-<p>It is possible to search for a module by title, department, skill category and so on.  
-To start, click <strong>Search Modules</strong> on 
+<p>It is possible to search for a course by title, department, skill category and so on.
+To start, click <strong>Search Courses</strong> on
 the <strong>Home</strong> page or in the navigation 
 menu at the top of the page.  The resultant page will display a search box.</p>
 <p>To search:</p>
@@ -35,27 +35,27 @@ then all upcoming courses are listed. You can refine your search later. </li>
 
 <p>Click <strong>Browse by Department</strong> on the <strong>Home</strong> page or in the navigation 
 menu at the top of the page.  The resultant page will display a list of training providers. 
-To browse the modules:</p>
+To browse the courses:</p>
 <ol>
   <li>Click on the unit of interest, you may see a list of courses or a further list of units. Keep going until you find a list of courses from the desired unit. </li>
   <li>MPLS and Social Sciences courses are colour coded; this is not the case for other training providers. 
-Modules in green are available for sign up, modules in black are not available for sign up and those 
-in red are already full. (Modules in green also contain the number of days left before the 
+Courses in green are available for sign up, courses in black are not available for sign up and those
+in red are already full. (Courses in green also contain the number of days left before the
 course is closed for signup.)</li>
-  <li>Click on an individual Module in the navigation tree to display the corresponding Module information on the right.</li>
+  <li>Click on an individual Course in the navigation tree to display the corresponding Course information on the right.</li>
   <li>Click the signup button or hyperlink if you wish to sign up for the course.  </li>
 </ol>
 
 <h3>Browse by Calendar</h3>
 
 <p>Click <strong>Browse by Calendar</strong> on the <strong>Home</strong> page or in the 
-navigation menu to see a list of upcoming modules ordered by starting date. Note the 
+navigation menu to see a list of upcoming courses ordered by starting date. Note the
 link to 'courses without dates' (which includes on-line resources).</p>
 <ol>
   <li>The list may be filtered by training provider.  Select a provider from the drop-down list at the 
-head of the table of modules and then click on the <strong>Filter</strong> button.</li>
-  <li>The status column shows if a module is open for signup, is not yet available, has closed, or is full</li>
-  <li>Click on the title of a module to view the module details and signup (if available).</li>	
+head of the table of courses and then click on the <strong>Filter</strong> button.</li>
+  <li>The status column shows if a course is open for signup, is not yet available, has closed, or is full</li>
+  <li>Click on the title of a course to view the course details and signup (if available).</li>
 </ol>
 
 <h3>Search by Vitae RDF Domains and Subdomain</h3>
@@ -64,7 +64,7 @@ head of the table of modules and then click on the <strong>Filter</strong> butto
 navigation menu. At the top of the resultant page you will find some explanatory notes which explain 
 about the Vitae Researcher Development Framework (RDF).</p>
 
-<p>The so-called 'RDF Wheel' is interactive: you may click on a domain or sub-domain and see a list of course that may be relevant to the particular skill area. The resultant search results page can be used as described above in the 'Search Modules' section.</p>
+<p>The so-called 'RDF Wheel' is interactive: you may click on a domain or sub-domain and see a list of course that may be relevant to the particular skill area. The resultant search results page can be used as described above in the 'Search Courses' section.</p>
 
 
 </div>

--- a/help/src/course_signup/ses_module_admin.html
+++ b/help/src/course_signup/ses_module_admin.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html><head>
-<title>Module Administrators Guide</title>
+<title>Course Administrators Guide</title>
 <style type="text/css">
 </style>
 <link type="text/css" href="/library/skin/tool_base.css" media="all" rel="stylesheet" />
@@ -8,39 +8,39 @@
 </head>
 <body>
 <div class="helpBody">
-<h2>Module Administrators Guide</h2>
+<h2>Course Administrators Guide</h2>
 
-<h3 id="accepting">Accepting, Approving, Rejecting and Managing Waiting Lists for Students on a Module</h3>
+<h3 id="accepting">Accepting, Approving, Rejecting and Managing Waiting Lists for Students on a Course</h3>
 
-<p>If you are a <strong>Module Administrator</strong> you are able to accept, approve, and reject students who have enrolled on a module in your department. As the Module Administrator you have an overview for all of the modules that you are administering. </p>
-<h4>Accepting or Rejecting Students on a Module </h4>
+<p>If you are a <strong>Course Administrator</strong> you are able to accept, approve, and reject students who have enrolled on a course in your department. As the Course Administrator you have an overview for all of the courses that you are administering. </p>
+<h4>Accepting or Rejecting Students on a Course </h4>
 <ol>
-  <li>Click <strong>Module Signup</strong> on the left hand navigation menu, then click on  <strong>Pending Acceptances</strong> at the top of the page. </li>
-  <li>In this screen you will see all the students who have signed up for modules in your department whose status is marked 'pending'.</li>
+  <li>Click <strong>Course Signup</strong> on the left hand navigation menu, then click on  <strong>Pending Acceptances</strong> at the top of the page. </li>
+  <li>In this screen you will see all the students who have signed up for courses in your department whose status is marked 'pending'.</li>
   <li>On each student record on the far right under the heading Actions there are two options displayed as hyperlinks, <strong>ACCEPT</strong> or <strong>REJECT</strong>. </li>
-  <li>By clicking the relevant link the student will be accepted onto the module and an email will alert their supervisor to approve the student's attendance. By rejecting the student, they will be sent an email informing them that they cannot attend the course. </li>
+  <li>By clicking the relevant link the student will be accepted onto the course and an email will alert their supervisor to approve the student's attendance. By rejecting the student, they will be sent an email informing them that they cannot attend the course. </li>
 </ol>
-<h4>Approving a Student on a Module and by-passing the Supervisor Approval Process </h4>
+<h4>Approving a Student on a Course and by-passing the Supervisor Approval Process </h4>
 <ol>
-  <li><strong>Module Administrators</strong> are able to approve students, bypassing the process of supervisor's approval. When a student has been <strong>ACCEPTED</strong> on a module in the <strong>Pending Acceptances</strong> screen the hyperlinks under Actions change to <strong>APPROVE</strong> or <strong>REJECT</strong>. </li>
+  <li><strong>Course Administrators</strong> are able to approve students, bypassing the process of supervisor's approval. When a student has been <strong>ACCEPTED</strong> on a course in the <strong>Pending Acceptances</strong> screen the hyperlinks under Actions change to <strong>APPROVE</strong> or <strong>REJECT</strong>. </li>
 
   <li>By clicking <strong>APPROVE</strong> the student will be sent an email informing them that they have been approved and are able to attend the course. </li>
   </ol>
 
 <h4>Managing Students on a Waiting List</h4>
 <ol>
-  <li>Module administrators are able to manage students who wish to attend a course but have been placed on a waiting list due to the course being full. When a student has joined the waiting list they will appear under the module in <strong>Module Administration</strong>. </li>
-  <li>If a place becomes available due to a student withdrawing, module administrators can change the status of any student on the waiting list to <strong>ACCEPTED</strong>. This will generate an email to the student informing them they have a place on the module. </li>
+  <li>Course administrators are able to manage students who wish to attend a course but have been placed on a waiting list due to the course being full. When a student has joined the waiting list they will appear under the course in <strong>Course Administration</strong>. </li>
+  <li>If a place becomes available due to a student withdrawing, course administrators can change the status of any student on the waiting list to <strong>ACCEPTED</strong>. This will generate an email to the student informing them they have a place on the course. </li>
 </ol>
 
-<h3 id="withdrawing">Withdrawing a Student from a Module</h3>
-<p>Module administrators may find it necessary from time to time to withdraw a student during a later stage in the enrolment process. </p>
+<h3 id="withdrawing">Withdrawing a Student from a Course</h3>
+<p>Course administrators may find it necessary from time to time to withdraw a student during a later stage in the enrolment process. </p>
 <ol>
 <li>
-  Click on <strong>Module Administration</strong> at the top of the page.
+  Click on <strong>Course Administration</strong> at the top of the page.
 </li>
 
-<li>Select the module from which the student wishes to withdraw from the drop-down list at
+<li>Select the course from which the student wishes to withdraw from the drop-down list at
 the top of the page.
 </li>
 
@@ -53,27 +53,27 @@ the top of the page.
 
 </ol>
 
-<h3 id="uploading"> Bulk Registering of Students onto a Module</h3>
-<p>Module Administrators may wish to bulk register students onto modules in their department which are compulsory or to ensure that students within their home department are registered before opening the course for wider availability. </p>
+<h3 id="uploading"> Bulk Registering of Students onto a Course</h3>
+<p>Course Administrators may wish to bulk register students onto courses in their department which are compulsory or to ensure that students within their home department are registered before opening the course for wider availability. </p>
 <ol>
-  <li>To upload multiple students click the <strong>Module Administration</strong> link at the top. </li>
-  <li>Use the 'select a module' drop-down and find the module you wish to upload to. </li>
-  <li>At the bottom of the screen  on this module is a hyperlink <strong>Add Signup</strong>.</li>
+  <li>To upload multiple students click the <strong>Course Administration</strong> link at the top. </li>
+  <li>Use the 'select a course' drop-down and find the course you wish to upload to. </li>
+  <li>At the bottom of the screen  on this course is a hyperlink <strong>Add Signup</strong>.</li>
   <li>Click the link to bring up an area  in which you can enter either the students' email addresses or their SSO (Single Sign-On) username. </li>
   <li>Any email addresses added in this field must be an Oxford email address as external emails addresses will not be recognised by the system. In some cases, the student's department email address may not be recognised and a college email address should be used instead. </li>
   <li>An error message will alert you when an email address has not been recognised which can be remedied by the action in point 5.</li>
   <li>Click <strong>Find</strong> which will  take you to a list of users email addresses found on the system.</li>
-  <li>Tick the instance of the module you would like to sign the students up for under <strong>Select Modules</strong> and click <strong>Add</strong>.</li>
-  <li>The students will then appear on the module.</li>
-  <li>Module administrators</strong> can oversubscribe courses should they need to. </li>
+  <li>Tick the instance of the course you would like to sign the students up for under <strong>Select Courses</strong> and click <strong>Add</strong>.</li>
+  <li>The students will then appear on the course.</li>
+  <li>Course administrators</strong> can oversubscribe courses should they need to. </li>
   <li>When using the bulk signup facility it is important to <strong>APPROVE</strong> students as this method does not involve supervisor approvals. By approving students using the <strong>APPROVE</strong> hyperlink this will generate an email to the student indicating that they have been enrolled on the course. </li>
 </ol>
 
-<h3 id="viewing">Viewing All Students Attending a Module</h3>
-<p>Module administrators are able to  view a list of students who are enrolled on a module in their department. This can be used to produce an attendance list for the module and also provides an email address for each student. </p>
+<h3 id="viewing">Viewing All Students Attending a Course</h3>
+<p>Course administrators are able to  view a list of students who are enrolled on a course in their department. This can be used to produce an attendance list for the course and also provides an email address for each student. </p>
 <ol>
-  <li>To view module attendance, click the &#124;<strong>Module Administration</strong>&#124;link at the top. </li>
-  <li>Use the 'select a module' drop-down and find the module you wish to view. </li>
+  <li>To view course attendance, click the &#124;<strong>Course Administration</strong>&#124;link at the top. </li>
+  <li>Use the 'select a course' drop-down and find the course you wish to view. </li>
   <li>A list of students will appear and these can be sorted by status using the filters in the signups header.</li>
   <li>To create an attendance sheet, click on the <strong>Register</strong> link in the <strong>Attendance</strong> column, this will provide a PDF document which can be printed out and circulated around a classroom.
 Alternatively use the <strong>Export</strong> hyperlink in the
@@ -83,10 +83,10 @@ Excel or equivalent and can be copied into Word or any other text editor to crea
 </ol>
 
 
-<h3 id="bulk_email">Bulk Emailing Students on a Module</h3>
-<p>Module administrators are able to bulk email all students who have signed-up for a module and have been accepted. </p>
+<h3 id="bulk_email">Bulk Emailing Students on a Course</h3>
+<p>Course administrators are able to bulk email all students who have signed-up for a course and have been accepted. </p>
 <ol>
-  <li>Click on <strong>Module Administration</strong> and select the relevant module from the drop down list.</li>
+  <li>Click on <strong>Course Administration</strong> and select the relevant course from the drop down list.</li>
   <li>In the first 'summary' table click on the appropriate
 <img alt="Envelope" src="/library/image/silk/email_add.png"> icon
 in the <strong>Email</strong> column, this will auto-populate a message with the email

--- a/help/src/course_signup/ses_module_supervisor.html
+++ b/help/src/course_signup/ses_module_supervisor.html
@@ -9,18 +9,18 @@
 <body>
 <div class="helpBody">
 <h2>Supervisors Guide</h2>
-<h3 id="approving">Approving and Rejecting Students on a Module</h3>
+<h3 id="approving">Approving and Rejecting Students on a Course</h3>
 
 <p>If you are a supervisor you are able to approve and reject the requests from students under your 
-supervision who have enrolled on a module. You will receive an email when any of your 
-students enrol for a module asking you to approve or reject the request.  
+supervision who have enrolled on a course. You will receive an email when any of your
+students enrol for a course asking you to approve or reject the request.
  </p>
 <ol>
   <li>When you receive an automated email, click on the link provided in the email which will 
 take you into the Researcher Training tool. </li>
 
-  <li>When a student has been <strong>ACCEPTED</strong> by the module administrator they 
-will appear on the <strong>Module Administration</strong> page. 
+  <li>When a student has been <strong>ACCEPTED</strong> by the course administrator they
+will appear on the <strong>Course Administration</strong> page.
 Using the hyperlinks under Actions by each student's name you can change the status 
 to <strong>APPROVE</strong> or <strong>REJECT</strong>. </li>
   <li>By clicking <strong>APPROVE</strong> the student will be sent an email informing them that they 
@@ -29,10 +29,10 @@ clicking <strong>REJECT</strong> they will be sent an email informing them that 
 been rejected and are unable to attend the course.</li>
   </ol>
 
-<h3 id="viewing">Viewing Your Students Attending Modules</h3>
+<h3 id="viewing">Viewing Your Students Attending Courses</h3>
 <p>Supervisors are able to  view a list of their students who are enrolled on courses throughout the Division. </p>
 <ol>
-  <li>To view module attendance, click the <strong>Module Administration</strong> link at the top of the page. </li>
+  <li>To view course attendance, click the <strong>Course Administration</strong> link at the top of the page. </li>
   <li>A list of students will appear and these can be modified using the <strong>Status Filter<strong>.</li>
   <li>You have the option of changing a student's status in this screen by using the drop down list next to each name.</li>
 </ol>

--- a/help/src/course_signup/ses_modulefull.html
+++ b/help/src/course_signup/ses_modulefull.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html><head>
-<title>What to do if a Module is Full</title>
+<title>What to do if a Course is Full</title>
 <style type="text/css">
 </style>
 <link type="text/css" href="/library/skin/tool_base.css" media="all" rel="stylesheet" />
@@ -8,9 +8,9 @@
 </head>
 <body>
 <div class="helpBody">
-<h2>What to do if a Module is Full</h2>
+<h2>What to do if a Course is Full</h2>
 <p>This only applies to courses that can be booked in this tool - this means courses offered by Social Sciences and MPLS.</p>
-<p>If you find a module you would like to enrol for but it is full you have the option of being added to a waiting list. In the module you are trying to enrol for, click on the <strong>Join Waiting List</strong> button which will prompt you to add your supervisor's email and reasons for attending the course. If a place becomes available on the course you will receive an email confirmation offering you a place from the <strong>Module Administrator</strong>. </p>
+<p>If you find a course you would like to enrol for but it is full you have the option of being added to a waiting list. In the course you are trying to enrol for, click on the <strong>Join Waiting List</strong> button which will prompt you to add your supervisor's email and reasons for attending the course. If a place becomes available on the course you will receive an email confirmation offering you a place from the <strong>Course Administrator</strong>. </p>
 
 </div>
 </body></html>

--- a/help/src/course_signup/ses_mystatus.html
+++ b/help/src/course_signup/ses_mystatus.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html><head>
-<title>Checking My Status on a Module</title>
+<title>Checking My Status on a Course</title>
 <style type="text/css">
 </style>
 <link type="text/css" href="/library/skin/tool_base.css" media="all" rel="stylesheet" />
@@ -8,32 +8,32 @@
 </head>
 <body>
 <div class="helpBody">
-<h2>Checking My Status on a Module</h2>
+<h2>Checking My Status on a Course</h2>
 <p>This only applies to courses that can be booked in this tool - this means courses offered by Social Sciences and MPLS.</p>
-<p>Click on <strong>My Modules</strong> at the top of the <strong>Module Signup</strong> page.
-<p>A list of Modules you have applied for is displayed including your status: either <strong>PENDING</strong>,
- <strong>ACCEPTED</strong>, <strong>APPROVED</strong>, <strong>CONFIRMED</strong>, <strong>WITHDRAWN</strong>  or <strong>REJECTED</strong>. You can use the filters on the header to sort your modules by module, by supervisor, and by status. </p>
+<p>Click on <strong>My Courses</strong> at the top of the <strong>Course Signup</strong> page.
+<p>A list of Courses you have applied for is displayed including your status: either <strong>PENDING</strong>,
+ <strong>ACCEPTED</strong>, <strong>APPROVED</strong>, <strong>CONFIRMED</strong>, <strong>WITHDRAWN</strong>  or <strong>REJECTED</strong>. You can use the filters on the header to sort your courses by course, by supervisor, and by status. </p>
 
 <ol><li>
-  <p><strong>PENDING</strong> This status indicates you have applied for the course and are waiting for confirmation from the Module Administrator. </p>
+  <p><strong>PENDING</strong> This status indicates you have applied for the course and are waiting for confirmation from the Course Administrator. </p>
 </li>
  <li>
-   <p><strong>ACCEPTED</strong> Once a Module Administrator has confirmed your signup the status for this module will change to accepted. </p>
+   <p><strong>ACCEPTED</strong> Once a Course Administrator has confirmed your signup the status for this course will change to accepted. </p>
  </li>
 <li>
-  <p><strong>APPROVED</strong> When a Module Administrator has accepted you onto the module, an email is sent to your supervisor. Once he or she has approved your attendance on the course, the status will change to approved. </p>
+  <p><strong>APPROVED</strong> When a Course Administrator has accepted you onto the course, an email is sent to your supervisor. Once he or she has approved your attendance on the course, the status will change to approved. </p>
 </li>
 <li>
   <p><strong>CONFIRMED</strong> This is the top level of the approval process and your sign-up will change to confirmed once the process has been completed. </p>
 </li>
 <li>
-<p><strong>WAITING</strong> This status means that you have signed-up on the module waiting list and you will be informed by the <strong>Module Administrator</strong> when a place becomes available.</p>
+<p><strong>WAITING</strong> This status means that you have signed-up on the course waiting list and you will be informed by the <strong>Course Administrator</strong> when a place becomes available.</p>
  </li>
 <li>
-<p><strong>WITHDRAWN</strong> In this screen you have the option to withdraw from a course. By clicking the withdraw link on the far right of the module you will be withdrawn from the course.</p>
+<p><strong>WITHDRAWN</strong> In this screen you have the option to withdraw from a course. By clicking the withdraw link on the far right of the course you will be withdrawn from the course.</p>
  </li>
 <li>
-  <p><strong>REJECTED</strong> If your supervisor does not think you should attend the course they will reject your request. You will be sent an email indicating this but your status will also change to rejected by the module. A Module Administrator may also wish to reject you before the supervisor approval stage and again you will be notified by email. </p>
+  <p><strong>REJECTED</strong> If your supervisor does not think you should attend the course they will reject your request. You will be sent an email indicating this but your status will also change to rejected by the course. A Course Administrator may also wish to reject you before the supervisor approval stage and again you will be notified by email. </p>
 </li></ol>
 
 </div>

--- a/help/src/course_signup/ses_overview.html
+++ b/help/src/course_signup/ses_overview.html
@@ -11,7 +11,7 @@
 <h2>Researcher Training tool: Overview</h2>
 <h3>What it does</h3>
 <p>The Researcher Training tool (which was formerly known as the Student Enrolment System (or SES)) is a
-discovery and  enrolment tool offering an extensive range of courses and modules from <strong>all</strong> of the 
+discovery and  enrolment tool offering an extensive range of courses and courses from <strong>all</strong> of the
 university's graduate training providers. These are:</p>
 
 
@@ -37,7 +37,7 @@ work-flow. For all other training providers, the tool acts as a launch-pad into 
 registration system. At the bottom of each course information page there is either 
 a 'Sign up' button or a link to the relevant external system.</p>
 
-<p>In MPLS the tool is also used for module sign-up  and includes academic courses, research, teaching, 
+<p>In MPLS the tool is also used for course sign-up  and includes academic courses, research, teaching,
 transferable skills and career development training. These courses make up the 
 Graduate Academic Programme from which you and your supervisor are able to tailor a 
 customised training programme to suit your individual needs and interests. </p>
@@ -47,8 +47,8 @@ Earth Sciences, Engineering, Materials, Mathematics, Physics, Plant Sciences, St
 the Oxford eResearch Centre, and the Doctoral Training Centres in the Life Sciences Interface, 
 Systems Biology, and Systems Approaches to Biomedical Science. </p>
 
-<p>Social Sciences (SSD)  also use the tool for module sign-up and is available to all graduate students 
-to register for modules and courses that are shared across the social science 
+<p>Social Sciences (SSD)  also use the tool for course sign-up and is available to all graduate students
+to register for courses and courses that are shared across the social science
 departments and for activities coordinated by the SSD divisional office.</p>
 
 <p>The departments that form the SSD academic division are: Anthropology, Archaeology, Economics, 
@@ -63,25 +63,25 @@ following user types in order to navigate around the help documentation. </p>
 
 <p><strong>Students and Researchers</strong></p>
 <ul>
-  <li><a href="content.hlp?docId=ses_browsing">Browsing / Searching for a Module</a></li>
-  <li><a href="content.hlp?docId=ses_signup">Signing Up for a Module</a></li>
-  <li><a href="content.hlp?docId=ses_modulefull">What to do if a Module is Full</a></li>
-  <li><a href="content.hlp?docId=ses_mystatus">Checking My Status on a Module</a></li>
-  <li><a href="content.hlp?docId=ses_withdrawing">Withdrawing from a Module</a></li>
+  <li><a href="content.hlp?docId=ses_browsing">Browsing / Searching for a Course</a></li>
+  <li><a href="content.hlp?docId=ses_signup">Signing Up for a Course</a></li>
+  <li><a href="content.hlp?docId=ses_modulefull">What to do if a Course is Full</a></li>
+  <li><a href="content.hlp?docId=ses_mystatus">Checking My Status on a Course</a></li>
+  <li><a href="content.hlp?docId=ses_withdrawing">Withdrawing from a Course</a></li>
 
 </ul>
-<p><strong>Module Administrators Guide</strong></p>
+<p><strong>Course Administrators Guide</strong></p>
 <ul>
-  <li><a href="content.hlp?docId=ses_module_admin#accepting">Accepting, Approving, Rejecting and Managing Waiting Lists for Students on a Module</a></li>
-  <li><a href="content.hlp?docId=ses_module_admin#withdrawing">Withdrawing a Student from a Module</a></li>
-  <li><a href="content.hlp?docId=ses_module_admin#uploading">Uploading Students onto a Module</a></li>
-  <li><a href="content.hlp?docId=ses_module_admin#viewing">Viewing All Students Attending a Module</a></li>
-  <li><a href="content.hlp?docId=ses_module_admin#bulk_email">Bulk Emailing Students on a Module</a></li>
+  <li><a href="content.hlp?docId=ses_module_admin#accepting">Accepting, Approving, Rejecting and Managing Waiting Lists for Students on a Course</a></li>
+  <li><a href="content.hlp?docId=ses_module_admin#withdrawing">Withdrawing a Student from a Course</a></li>
+  <li><a href="content.hlp?docId=ses_module_admin#uploading">Uploading Students onto a Course</a></li>
+  <li><a href="content.hlp?docId=ses_module_admin#viewing">Viewing All Students Attending a Course</a></li>
+  <li><a href="content.hlp?docId=ses_module_admin#bulk_email">Bulk Emailing Students on a Course</a></li>
 </ul>
 <p><strong>Supervisors Guide</strong></p>
 <ul>
-  <li><a href="content.hlp?docId=ses_module_supervisor#approving">Approving and Rejecting Students on a Module</a></li>
-  <li><a href="content.hlp?docId=ses_module_supervisor#viewing">Viewing Your Students Attending Modules</a></li>
+  <li><a href="content.hlp?docId=ses_module_supervisor#approving">Approving and Rejecting Students on a Course</a></li>
+  <li><a href="content.hlp?docId=ses_module_supervisor#viewing">Viewing Your Students Attending Courses</a></li>
 </ul>
 </div>
 </body></html>

--- a/help/src/course_signup/ses_signup.html
+++ b/help/src/course_signup/ses_signup.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html><head>
-<title>Signing Up for a Module</title>
+<title>Signing Up for a Course</title>
 <style type="text/css">
 		/* Style for specific inline images */
 		
@@ -13,35 +13,35 @@
 </head>
 <body>
 <div class="helpBody">
-<h2>Signing Up for a Module</h2>
+<h2>Signing Up for a Course</h2>
 
-<h3>Signing Up for a Social Sciences or MPLS Module</h3>
+<h3>Signing Up for a Social Sciences or MPLS Course</h3>
 
-<p>This is only relevant for modules run by the Social Sciences or MPLS divisions.</p>
-<p>Once you have found a module that you would like to attend, please carefully check that you fulfil the eligibility criteria to make sure the course is suitable for you. Please also ensure that you are able to attend the module on the date and times specified. </p>
+<p>This is only relevant for courses run by the Social Sciences or MPLS divisions.</p>
+<p>Once you have found a course that you would like to attend, please carefully check that you fulfil the eligibility criteria to make sure the course is suitable for you. Please also ensure that you are able to attend the course on the date and times specified. </p>
 <p>
-<strong>Note:</strong> If the module is marked <strong>Full</strong> then 
-read <a href="content.hlp?docId=ses_modulefull">What to do if a Module is Full</a>.</p> 
+<strong>Note:</strong> If the course is marked <strong>Full</strong> then
+read <a href="content.hlp?docId=ses_modulefull">What to do if a Course is Full</a>.</p>
 
 <ol><li>
-  <p>Select the module parts you wish attend by clicking the radio button next to the option which suits you &#45; this will be made clear in the description (for example, you may be required to sign up 
-for both a Laboratory and Lecture series).  In many cases there will be only one module part to select. Click the grey <strong>Signup</strong> button at the bottom of the course description. </p>
+  <p>Select the course parts you wish attend by clicking the radio button next to the option which suits you &#45; this will be made clear in the description (for example, you may be required to sign up
+for both a Laboratory and Lecture series).  In many cases there will be only one course part to select. Click the grey <strong>Signup</strong> button at the bottom of the course description. </p>
 </li>
 
 <li>
-  <p>A pop up window will ask for your supervisor&#39;s email address and your reasons for wanting to attend the Module. 
-This is needed because your supervisor&#39;s permission is required for you to attend any training Modules. To continue, click 'Confirm Signup' or 'Cancel' if you no longer wish to enrol for the course. </p>
+  <p>A pop up window will ask for your supervisor&#39;s email address and your reasons for wanting to attend the Course.
+This is needed because your supervisor&#39;s permission is required for you to attend any training Courses. To continue, click 'Confirm Signup' or 'Cancel' if you no longer wish to enrol for the course. </p>
   <p><strong>Note:</strong> You will need to enter
 an email address recognised by the University.  </p></li>
 
-<li><p>Following submission an email will be sent to your <strong>Supervisor</strong> and the <strong>Module Administrator</strong> for approval.</p></li>
+<li><p>Following submission an email will be sent to your <strong>Supervisor</strong> and the <strong>Course Administrator</strong> for approval.</p></li>
 
 <li>
-  <p>When approval has been granted you will be notified via email that you have a place on the Module. You will also be notified if approval is not granted.</p>
+  <p>When approval has been granted you will be notified via email that you have a place on the Course. You will also be notified if approval is not granted.</p>
 </li></ol>
 
-<h3>Signing Up for a Module Offered by the Other Training Providers</h3>
-<p>Once you have found a module that you would like to attend, please carefully check that you fulfil the eligibility criteria to make sure the course is suitable for you. Please also ensure that you are able to attend the module on the date and times specified. </p>
+<h3>Signing Up for a Course Offered by the Other Training Providers</h3>
+<p>Once you have found a course that you would like to attend, please carefully check that you fulfil the eligibility criteria to make sure the course is suitable for you. Please also ensure that you are able to attend the course on the date and times specified. </p>
 
 <p>Click on the hyperlink given at the bottom of the page, this will take you to the training provider&#39;s
 website. Depending  on the course that was selected, you may need to supply a username and password.</p>

--- a/help/src/course_signup/ses_withdrawing.html
+++ b/help/src/course_signup/ses_withdrawing.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html><head>
-<title>Withdrawing from a Module</title>
+<title>Withdrawing from a Course</title>
 <style type="text/css">
 </style>
 <link type="text/css" href="/library/skin/tool_base.css" media="all" rel="stylesheet" />
@@ -8,23 +8,23 @@
 </head>
 <body>
 <div class="helpBody">
-<h2>Withdrawing from a Module</h2>
+<h2>Withdrawing from a Course</h2>
 
 <p>This only applies to courses that can be booked in this tool - this means courses offered by Social Sciences and MPLS.</p>
 
-<p>Check the status of your application by clicking on <strong>My Modules</strong> and following the corresponding instructions below. </p>
-<p>If your status on the Module is <strong>PENDING</strong> </p>
-<ol><li>Click on <strong>My Modules</strong> at the top of the page. </li>
+<p>Check the status of your application by clicking on <strong>My Courses</strong> and following the corresponding instructions below. </p>
+<p>If your status on the Course is <strong>PENDING</strong> </p>
+<ol><li>Click on <strong>My Courses</strong> at the top of the page. </li>
 
-<li>In the status column next to the Module you wish to withdraw from will be link labelled 'Withdraw'.  By selecting this you will be <strong>WITHDRAWN</strong>.  </li>
+<li>In the status column next to the Course you wish to withdraw from will be link labelled 'Withdraw'.  By selecting this you will be <strong>WITHDRAWN</strong>.  </li>
 
-<li>An email will be sent to both the <strong>Module Administrator</strong> and your 
+<li>An email will be sent to both the <strong>Course Administrator</strong> and your
 <strong>Supervisor</strong> to notify them of your withdrawal. </li></ol>
 
-<p>If your status on the Module is <strong>APPROVED</strong> </p>
+<p>If your status on the Course is <strong>APPROVED</strong> </p>
 <ol>
-  <li>If you have been <strong>APPROVED</strong> on a Module you will need to email the <strong>Module Administrator</strong> in order to withdraw.  
-    The details of the <strong>Module Administrator</strong> are found on the acceptance email you received.  
+  <li>If you have been <strong>APPROVED</strong> on a Course you will need to email the <strong>Course Administrator</strong> in order to withdraw.
+    The details of the <strong>Course Administrator</strong> are found on the acceptance email you received.
   </li>
 </ol>
 </div>

--- a/impl/src/main/java/uk/ac/ox/oucs/vle/CourseDAO.java
+++ b/impl/src/main/java/uk/ac/ox/oucs/vle/CourseDAO.java
@@ -114,10 +114,7 @@ public interface CourseDAO {
 	void save(CourseOucsDepartmentDAO oucsDao);
 
 	void remove(CourseSignupDAO existingSignup);
-	
-	CourseUserPlacementDAO findUserPlacement(String userId);
-	
-	void save(CourseUserPlacementDAO placementDao);
+
 	
 	public int flagSelectedCourseGroups(final String source);
 	

--- a/impl/src/main/java/uk/ac/ox/oucs/vle/CourseDAOImpl.java
+++ b/impl/src/main/java/uk/ac/ox/oucs/vle/CourseDAOImpl.java
@@ -721,27 +721,6 @@ public class CourseDAOImpl extends HibernateDaoSupport implements CourseDAO {
 		getHibernateTemplate().clear();
 	}
 
-	@SuppressWarnings("unchecked")
-	public CourseUserPlacementDAO findUserPlacement(final String userId) {
-		List<Object> results = getHibernateTemplate().executeFind(new HibernateCallback() {
-			public Object doInHibernate(Session session) {
-				Query query = session.createSQLQuery(
-						"select * from course_user_placement " +
-						"where userId = :userId").addEntity(CourseUserPlacementDAO.class);
-				query.setString("userId", userId);
-				return query.list();
-			}
-		});
-		if (!results.isEmpty()) {
-			return (CourseUserPlacementDAO)results.get(0);
-		}
-		return null;
-	}
-
-	public void save(CourseUserPlacementDAO placementDao) {
-		getHibernateTemplate().save(placementDao).toString();
-	}
-	
 	/**
 	 * 
 	 */

--- a/impl/src/main/java/uk/ac/ox/oucs/vle/CourseDepartmentImpl.java
+++ b/impl/src/main/java/uk/ac/ox/oucs/vle/CourseDepartmentImpl.java
@@ -1,0 +1,34 @@
+package uk.ac.ox.oucs.vle;
+
+import java.util.Set;
+
+/**
+ * Created by buckett on 24/09/15.
+ */
+public class CourseDepartmentImpl implements CourseDepartment {
+
+    private String code;
+    private boolean approvalRequired;
+    private Set<String> approvers;
+
+    public CourseDepartmentImpl(String code, boolean approvalRequired, Set<String> approvers) {
+        this.code = code;
+        this.approvalRequired = approvalRequired;
+        this.approvers = approvers;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public boolean isApprovalRequired() {
+        return approvalRequired;
+    }
+
+    @Override
+    public Set<String> getApprovers() {
+        return approvers;
+    }
+}

--- a/impl/src/main/java/uk/ac/ox/oucs/vle/ModuleImpl.java
+++ b/impl/src/main/java/uk/ac/ox/oucs/vle/ModuleImpl.java
@@ -68,6 +68,8 @@ public class ModuleImpl implements Module {
 	 * The proxy for getting users.
 	 */
 	private SakaiProxy proxy;
+
+	private UserPlacementDAO placementDAO;
 	
 	
 	public void setCourseDao(CourseDAO dao) {
@@ -77,7 +79,11 @@ public class ModuleImpl implements Module {
 	public void setProxy(SakaiProxy proxy) {
 		this.proxy = proxy;
 	}
-	
+
+	public void setPlacementDAO(UserPlacementDAO placementDAO) {
+		this.placementDAO = placementDAO;
+	}
+
 	/**
 	 * 
 	 */
@@ -312,7 +318,7 @@ public class ModuleImpl implements Module {
 			log.warn("Failed to find user for sending email: "+ signup.getUserId());
 			return;
 		}
-		CourseUserPlacementDAO placementDao = dao.findUserPlacement(signup.getUserId());
+		CourseUserPlacementDAO placementDao = placementDAO.findUserPlacement(signup.getUserId());
 		if (null == placementDao) {
 			log.warn("Failed to find placement for sending email: "+ signup.getUserId());
 			return;
@@ -350,7 +356,7 @@ public class ModuleImpl implements Module {
 			signupsDetails.append("\n");
 		}
 		
-		CourseUserPlacementDAO placementDao = dao.findUserPlacement(administratorId);
+		CourseUserPlacementDAO placementDao = placementDAO.findUserPlacement(administratorId);
 		if (null == placementDao) {
 			log.warn("Failed to find placement for sending email: "+ administratorId);
 			return;
@@ -386,7 +392,7 @@ public class ModuleImpl implements Module {
 			signupsDetails.append("\n");
 		}
 		
-		CourseUserPlacementDAO placementDao = dao.findUserPlacement(supervisorId);
+		CourseUserPlacementDAO placementDao = placementDAO.findUserPlacement(supervisorId);
 		if (null == placementDao) {
 			log.warn("Failed to find placement for sending email: "+ supervisorId);
 			return;

--- a/impl/src/main/java/uk/ac/ox/oucs/vle/UserPlacementDAO.java
+++ b/impl/src/main/java/uk/ac/ox/oucs/vle/UserPlacementDAO.java
@@ -1,0 +1,10 @@
+package uk.ac.ox.oucs.vle;
+
+
+public interface UserPlacementDAO {
+
+    CourseUserPlacementDAO findUserPlacement(String userId);
+
+    void save(CourseUserPlacementDAO placementDao);
+
+}

--- a/impl/src/main/java/uk/ac/ox/oucs/vle/UserPlacmentDAOImpl.java
+++ b/impl/src/main/java/uk/ac/ox/oucs/vle/UserPlacmentDAOImpl.java
@@ -1,0 +1,36 @@
+package uk.ac.ox.oucs.vle;
+
+import org.hibernate.Query;
+import org.hibernate.Session;
+import org.springframework.orm.hibernate3.HibernateCallback;
+import org.springframework.orm.hibernate3.support.HibernateDaoSupport;
+
+import java.util.List;
+
+/**
+ * Created by buckett on 24/09/15.
+ */
+public class UserPlacmentDAOImpl extends HibernateDaoSupport implements UserPlacementDAO {
+
+    @SuppressWarnings("unchecked")
+    public CourseUserPlacementDAO findUserPlacement(final String userId) {
+        List<Object> results = getHibernateTemplate().executeFind(new HibernateCallback() {
+            public Object doInHibernate(Session session) {
+                Query query = session.createSQLQuery(
+                        "select * from course_user_placement " +
+                                "where userId = :userId").addEntity(CourseUserPlacementDAO.class);
+                query.setString("userId", userId);
+                return query.list();
+            }
+        });
+        if (!results.isEmpty()) {
+            return (CourseUserPlacementDAO)results.get(0);
+        }
+        return null;
+    }
+
+    public void save(CourseUserPlacementDAO placementDao) {
+        getHibernateTemplate().save(placementDao).toString();
+    }
+
+}

--- a/impl/src/main/java/uk/ac/ox/oucs/vle/email/AcceptedEmailRule.java
+++ b/impl/src/main/java/uk/ac/ox/oucs/vle/email/AcceptedEmailRule.java
@@ -1,0 +1,39 @@
+package uk.ac.ox.oucs.vle.email;
+
+import uk.ac.ox.oucs.vle.CourseSignup;
+import uk.ac.ox.oucs.vle.CourseSignupImpl;
+import uk.ac.ox.oucs.vle.CourseSignupService;
+import uk.ac.ox.oucs.vle.Person;
+
+import static uk.ac.ox.oucs.vle.CourseSignupService.Status;
+
+import static uk.ac.ox.oucs.vle.CourseSignupService.Status.*;
+
+/**
+ * Sends an email to the supervisor about the signup.
+ */
+public class AcceptedEmailRule extends EmailRule {
+
+    @Override
+    public boolean matches(StateChange stateChange) {
+        return Status.matches(stateChange.getOldStatus(), PENDING, WAITING) &&
+            Status.matches(stateChange.getSignup().getStatus(),ACCEPTED);
+    }
+
+    @Override
+    public void perform(StateChange stateChange) {
+        CourseSignup signup = stateChange.getSignup();
+        Person supervisor = signup.getSupervisor();
+        if (supervisor == null) {
+            throw new IllegalStateException("Signup without a supervisor can't get approval");
+        }
+        String placementId = stateChange.getPlacement();
+        String url = proxy.getConfirmUrl(signup.getId(), placementId);
+        String advanceUrl = proxy.getAdvanceUrl(signup.getId(), "approve", placementId);
+        service.sendSignupEmail(supervisor.getId(), signup,
+                "approval.supervisor.subject",
+                "approval.supervisor.body",
+                new Object[]{url, advanceUrl});
+        service.savePlacement(supervisor.getId(), placementId);
+    }
+}

--- a/impl/src/main/java/uk/ac/ox/oucs/vle/email/ApprovedEmailRule.java
+++ b/impl/src/main/java/uk/ac/ox/oucs/vle/email/ApprovedEmailRule.java
@@ -1,0 +1,42 @@
+package uk.ac.ox.oucs.vle.email;
+
+import uk.ac.ox.oucs.vle.CourseDepartment;
+import uk.ac.ox.oucs.vle.CourseSignup;
+import uk.ac.ox.oucs.vle.CourseSignupService;
+import uk.ac.ox.oucs.vle.CourseSignupService.Status;
+
+import static uk.ac.ox.oucs.vle.CourseSignupService.Status.APPROVED;
+
+/**
+ * When a signup is approved an email goes out asking for department approvers to
+ * allow the signup.
+ */
+public class ApprovedEmailRule extends EmailRule {
+    @Override
+    public boolean matches(StateChange stateChange) {
+        return Status.matches(stateChange.getSignup().getStatus(), APPROVED);
+    }
+
+    @Override
+    public void perform(StateChange stateChange) {
+        String signupId = stateChange.getSignup().getId();
+        String placementId = stateChange.getPlacement();
+        CourseSignup signup = stateChange.getSignup();
+        CourseDepartment department= stateChange.getDepartment();
+
+        for (String approverId : department.getApprovers()) {
+            String url = proxy.getApproveUrl(signupId, placementId);
+            String advanceUrl = proxy.getAdvanceUrl(signup.getId(), "confirm", placementId);
+            if (approverId != null) {
+                service.sendSignupEmail(
+                        approverId, signup,
+                        "approval.supervisor.subject",
+                        "approval.supervisor.body",
+                        new Object[]{url, advanceUrl});
+                service.savePlacement(approverId, placementId);
+            }
+        }
+
+
+    }
+}

--- a/impl/src/main/java/uk/ac/ox/oucs/vle/email/ConfirmedEmailRule.java
+++ b/impl/src/main/java/uk/ac/ox/oucs/vle/email/ConfirmedEmailRule.java
@@ -1,0 +1,25 @@
+package uk.ac.ox.oucs.vle.email;
+
+import uk.ac.ox.oucs.vle.CourseSignupService;
+import uk.ac.ox.oucs.vle.CourseSignupService.Status;
+
+import static uk.ac.ox.oucs.vle.CourseSignupService.Status.CONFIRMED;
+
+/**
+ * Created by buckett on 02/10/15.
+ */
+public class ConfirmedEmailRule extends EmailRule {
+    @Override
+    public boolean matches(StateChange stateChange) {
+        return Status.matches(stateChange.getSignup().getStatus(), CONFIRMED);
+    }
+
+    @Override
+    public void perform(StateChange stateChange) {
+        String url = proxy.getMyUrl(stateChange.getPlacement());
+        service.sendStudentSignupEmail(stateChange.getSignup(),
+                "confirmed.student.subject",
+                "confirmed.student.body",
+                new Object[]{url});
+    }
+}

--- a/impl/src/main/java/uk/ac/ox/oucs/vle/email/EmailRule.java
+++ b/impl/src/main/java/uk/ac/ox/oucs/vle/email/EmailRule.java
@@ -1,0 +1,27 @@
+package uk.ac.ox.oucs.vle.email;
+
+import uk.ac.ox.oucs.vle.SakaiProxy;
+
+/**
+ * Rule for sending out email based on changes to signups.
+ */
+public abstract class EmailRule {
+
+    protected EmailSendingService service;
+
+    // Having the proxy used isn't ideal as it exposes things like
+    // the current user which means we can't send emails later
+    protected SakaiProxy proxy;
+
+    public void setService(EmailSendingService service) {
+        this.service = service;
+    }
+
+    public void setProxy(SakaiProxy proxy) {
+        this.proxy = proxy;
+    }
+
+    public abstract boolean matches(StateChange stateChange);
+
+    public abstract void perform(StateChange stateChange);
+}

--- a/impl/src/main/java/uk/ac/ox/oucs/vle/email/EmailSendingService.java
+++ b/impl/src/main/java/uk/ac/ox/oucs/vle/email/EmailSendingService.java
@@ -1,0 +1,248 @@
+/*
+ * #%L
+ * Course Signup Implementation
+ * %%
+ * Copyright (C) 2010 - 2015 University of Oxford
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package uk.ac.ox.oucs.vle.email;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import uk.ac.ox.oucs.vle.*;
+
+import java.text.MessageFormat;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Centralise all our event based email sending.
+ */
+public class EmailSendingService {
+
+    private Log log = LogFactory.getLog(EmailSendingService.class);
+
+    private SakaiProxy proxy;
+    private UserPlacementDAO placementDAO;
+    private Set<EmailRule> rules;
+
+    public void setProxy(SakaiProxy proxy) {
+        this.proxy = proxy;
+    }
+
+    public void setPlacementDAO(UserPlacementDAO placementDAO) {
+        this.placementDAO = placementDAO;
+    }
+
+    public void setRules(Set<EmailRule> rules) {
+        this.rules = rules;
+    }
+
+    public void init() {
+        // This sets up all the rules so they can be used.
+        for (EmailRule rule: rules) {
+            rule.setProxy(proxy);
+            rule.setService(this);
+        }
+    }
+
+    /**
+     * This is the main entry point and runs all the email sending rules
+     * against the state sendMails.
+     * @param stateChange
+     */
+    public void applyRules(StateChange stateChange) {
+        Set<EmailRule> actions = new HashSet<>();
+        // See which rules match
+        for (EmailRule rule: rules) {
+            if (rule.matches(stateChange)) {
+                actions.add(rule);
+            }
+        }
+
+        // Perform the actions for the matched rules
+        for (EmailRule action: actions) {
+            action.perform(stateChange);
+        }
+    }
+
+    /**
+     * Generic method for sending out a signup email.
+     * @param userId The ID of the user who the message should be sent to.
+     * @param signupDao The signup the message is about.
+     * @param subjectKey The resource bundle key for the subject
+     * @param bodyKey The resource bundle key for the body.
+     * @param additionalBodyData Additional objects used to format the email body. Typically used for the confirm URL.
+     * @param courseSignupService
+     */
+    public void sendSignupEmail(String userId, CourseSignup signup, String subjectKey,
+                                String bodyKey,
+                                Object[] additionalBodyData) {
+
+        UserProxy recepient = proxy.findUserById(userId);
+        if (recepient == null) {
+            log.warn("Failed to find user for sending email: "+ userId);
+            return;
+        }
+        Person person = signup.getUser();
+        if (person == null) {
+            log.warn("Failed to find the user who made the signup: " + signup.getId());
+            return;
+        }
+
+        String to = recepient.getEmail();
+        String componentDetails = formatSignup(signup);
+        Object[] baseBodyData = new Object[] {
+                proxy.getCurrentUser().getDisplayName(),
+                componentDetails,
+                signup.getGroup().getTitle(),
+                person.getName(),
+                (null == person.getDegreeProgram()) ? "unknown" : person.getDegreeProgram()
+        };
+        Object[] data = baseBodyData;
+        if (additionalBodyData != null) {
+            data = new Object[data.length + additionalBodyData.length];
+            System.arraycopy(baseBodyData, 0, data, 0, baseBodyData.length);
+            System.arraycopy(additionalBodyData, 0, data, baseBodyData.length, additionalBodyData.length);
+        }
+
+        String subject = MessageFormat.format(proxy.getMessage(subjectKey), data);
+        String body = MessageFormat.format(proxy.getMessage(bodyKey), data);
+        proxy.sendEmail(to, subject, body);
+    }
+
+    /**
+     *  @param signupDao
+     * @param subjectKey
+     * @param bodyKey
+     * @param additionalBodyData
+     * @param courseSignupService
+     */
+    public void sendStudentSignupEmail(CourseSignup signup, String subjectKey,
+                                       String bodyKey,
+                                       Object[] additionalBodyData) {
+
+        Person signupUser = signup.getUser();
+        if (signupUser == null) {
+            log.warn("Failed to find the user who made the signup: "+ signup.getId());
+            return;
+        }
+
+        String to = signupUser.getEmail();
+        String componentDetails = formatSignup(signup);
+        Object[] baseBodyData = new Object[] {
+                signupUser.getName(),
+                componentDetails,
+                signup.getGroup().getTitle(),
+        };
+
+        Object[] data = baseBodyData;
+        if (additionalBodyData != null) {
+            data = new Object[data.length + additionalBodyData.length];
+            System.arraycopy(baseBodyData, 0, data, 0, baseBodyData.length);
+            System.arraycopy(additionalBodyData, 0, data, baseBodyData.length, additionalBodyData.length);
+        }
+        String subject = MessageFormat.format(proxy.getMessage(subjectKey), data);
+        String body = MessageFormat.format(proxy.getMessage(bodyKey), data);
+        proxy.sendEmail(to, subject, body);
+    }
+
+    /**
+     *  @param userId
+     * @param signupDao
+     * @param subjectKey
+     * @param bodyKey
+     * @param additionalBodyData
+     * @param courseSignupService
+     */
+    public void sendSignupWaitingEmail(String userId, CourseSignup signup, String subjectKey, String bodyKey, Object[] additionalBodyData) {
+
+        UserProxy recepient = proxy.findUserById(signup.getUser().getId());
+        if (recepient == null) {
+            log.warn("Failed to find the user who made the signup: " + signup.getUser().getId());
+            return;
+        }
+        UserProxy signupUser = proxy.findUserById(userId);
+        if (signupUser == null) {
+            log.warn("Failed to find user for sending email: "+ userId);
+            return;
+        }
+
+        String to = recepient.getEmail();
+        String subject = MessageFormat.format(proxy.getMessage(subjectKey), new Object[]{proxy.getCurrentUser().getDisplayName(), signup.getGroup().getTitle(), signupUser.getDisplayName()});
+        String componentDetails = formatSignup(signup);
+        Object[] baseBodyData = new Object[] {
+                proxy.getCurrentUser().getDisplayName(),
+                componentDetails,
+                signup.getGroup().getTitle(),
+                signupUser.getDisplayName(),
+                (null == signupUser.getDegreeProgram()) ? "unknown" : signupUser.getDegreeProgram()
+        };
+        Object[] bodyData = baseBodyData;
+        if (additionalBodyData != null) {
+            bodyData = new Object[bodyData.length + additionalBodyData.length];
+            System.arraycopy(baseBodyData, 0, bodyData, 0, baseBodyData.length);
+            System.arraycopy(additionalBodyData, 0, bodyData, baseBodyData.length, additionalBodyData.length);
+        }
+        String body = MessageFormat.format(proxy.getMessage(bodyKey), bodyData);
+        proxy.sendEmail(to, subject, body);
+    }
+
+
+    // Computer-Aided Formal Verification (Computing Laboratory)
+    // - Lectures: 16 lectures for 16 sessions starts in Michaelmas 2010 with Daniel Kroening
+
+    /**
+     * This formats the details of a signup into plain text.
+     *
+     * @param signupDao
+     * @return
+     */
+    public String formatSignup(CourseSignup signup) {
+        StringBuilder output = new StringBuilder(); // TODO Maybe should use resource bundle.
+        output.append(signup.getGroup().getTitle());
+        output.append(" (");
+        output.append(signup.getGroup().getDepartment());
+        output.append(" )\n");
+        for(CourseComponent component: signup.getComponents()) {
+            output.append("  - ");
+            output.append(component.getTitle());
+            output.append("for ");
+            output.append(component.getSessions());
+            if (component.getWhen() != null) {
+                output.append(" starts in ");
+                output.append(component.getWhen());
+            }
+            Person presenter = component.getPresenter();
+            if(presenter != null) {
+                output.append(" with ");
+                output.append(presenter.getName());
+            }
+            output.append("\n");
+        }
+        return output.toString();
+    }
+
+
+    public CourseUserPlacementDAO savePlacement(String userId, String placementId) {
+        CourseUserPlacementDAO placementDao = placementDAO.findUserPlacement(userId);
+        if (null == placementDao) {
+            placementDao = new CourseUserPlacementDAO(userId);
+        }
+        placementDao.setPlacementId(placementId);
+        placementDAO.save(placementDao);
+        return placementDao;
+    }
+}

--- a/impl/src/main/java/uk/ac/ox/oucs/vle/email/FullEmailRule.java
+++ b/impl/src/main/java/uk/ac/ox/oucs/vle/email/FullEmailRule.java
@@ -1,0 +1,43 @@
+package uk.ac.ox.oucs.vle.email;
+
+import uk.ac.ox.oucs.vle.CourseGroup;
+import uk.ac.ox.oucs.vle.CourseSignup;
+import uk.ac.ox.oucs.vle.CourseSignupService;
+import uk.ac.ox.oucs.vle.CourseSignupService.Status;
+import uk.ac.ox.oucs.vle.Person;
+
+import static uk.ac.ox.oucs.vle.CourseSignupService.Status.WAITING;
+
+/**
+ * When a signup is made and the user is placed onto the waiting list send an email
+ * to the administrator of the course and to the signup.
+ */
+public class FullEmailRule extends EmailRule {
+    @Override
+    public boolean matches(StateChange stateChange) {
+        // No old status as it's a new signup.
+        return stateChange.getOldStatus() == null
+            && Status.matches(stateChange.getSignup().getStatus(), WAITING);
+    }
+
+    @Override
+    public void perform(StateChange stateChange) {
+        CourseSignup signup = stateChange.getSignup();
+        CourseGroup group = signup.getGroup();
+        for (Person administrator : group.getAdministrators()) {
+            service.sendSignupWaitingEmail(
+                    administrator.getId(), signup,
+                    "waiting.admin.subject",
+                    "waiting.admin.body",
+                    new Object[]{proxy.getAdminUrl()});
+            service.savePlacement(administrator.getId(), stateChange.getPlacement());
+        }
+
+        String myUrl = proxy.getMyUrl();
+        service.sendStudentSignupEmail(signup,
+                "waiting.student.subject",
+                "waiting.student.body",
+                new Object[]{myUrl});
+
+    }
+}

--- a/impl/src/main/java/uk/ac/ox/oucs/vle/email/PendingEmailRule.java
+++ b/impl/src/main/java/uk/ac/ox/oucs/vle/email/PendingEmailRule.java
@@ -1,0 +1,45 @@
+package uk.ac.ox.oucs.vle.email;
+
+import uk.ac.ox.oucs.vle.CourseGroup;
+import uk.ac.ox.oucs.vle.CourseSignup;
+import uk.ac.ox.oucs.vle.CourseSignupService;
+import uk.ac.ox.oucs.vle.CourseSignupService.Status;
+import uk.ac.ox.oucs.vle.Person;
+
+import static uk.ac.ox.oucs.vle.CourseSignupService.Status.PENDING;
+
+/**
+ * Send out an an email to course administrators when a new signup is made.
+ * Also send out an email to the student informing them about the signup.
+ */
+public class PendingEmailRule extends EmailRule {
+    @Override
+    public boolean matches(StateChange stateChange) {
+        return (stateChange.getOldStatus() == null)
+            && Status.matches(stateChange.getSignup().getStatus(), PENDING);
+    }
+
+    @Override
+    public void perform(StateChange stateChange) {
+        CourseSignup signup = stateChange.getSignup();
+        CourseGroup group = signup.getGroup();
+
+        String advanceUrl = proxy.getAdvanceUrl(signup.getId(), "accept", null);
+        String url = proxy.getConfirmUrl(signup.getId());
+        for (Person administrator : group.getAdministrators()) {
+            service.sendSignupEmail(
+                    administrator.getId(), signup,
+                    "signup.admin.subject",
+                    "signup.admin.body",
+                    new Object[]{url, advanceUrl});
+            service.savePlacement(administrator.getId(), stateChange.getPlacement());
+        }
+
+        String myUrl = proxy.getMyUrl();
+        service.sendStudentSignupEmail(signup,
+                "signup.student.subject",
+                "signup.student.body",
+                new Object[]{myUrl});
+
+    }
+}

--- a/impl/src/main/java/uk/ac/ox/oucs/vle/email/RejectedAcceptedEmailRule.java
+++ b/impl/src/main/java/uk/ac/ox/oucs/vle/email/RejectedAcceptedEmailRule.java
@@ -1,0 +1,43 @@
+package uk.ac.ox.oucs.vle.email;
+
+import uk.ac.ox.oucs.vle.CourseSignup;
+import uk.ac.ox.oucs.vle.CourseSignupService;
+import uk.ac.ox.oucs.vle.CourseSignupService.Status;
+
+import static uk.ac.ox.oucs.vle.CourseSignupService.Status.*;
+
+/**
+ * Rule for when someone is rejected from attending a module when they were accepted.
+ */
+public class RejectedAcceptedEmailRule extends EmailRule {
+
+    @Override
+    public boolean matches(StateChange stateChange) {
+        return Status.matches(stateChange.getOldStatus(), ACCEPTED) &&
+                Status.matches(stateChange.getSignup().getStatus(), REJECTED);
+    }
+
+    @Override
+    public void perform(StateChange stateChange) {
+        CourseSignup signup = stateChange.getSignup();
+        String placementId = stateChange.getPlacement();
+        if (signup.getSupervisor() == null) {
+            service.sendStudentSignupEmail(
+                    signup,
+                    "reject-admin.student.subject",
+                    "reject-admin.student.body",
+                    new Object[] {proxy.getCurrentUser().getDisplayName(), proxy.getMyUrl(placementId)});
+        } else {
+            // This may tell the user that the supervisor rejected them, when infact the user might have
+            // been the administrator at the time.
+            service.sendStudentSignupEmail(
+                    signup,
+                    "reject-supervisor.student.subject",
+                    "reject-supervisor.student.body",
+                    new Object[] {signup.getSupervisor().getName(), proxy.getMyUrl(placementId)});
+        }
+        service.savePlacement(stateChange.getSignup().getUser().getId(), stateChange.getPlacement());
+
+    }
+
+}

--- a/impl/src/main/java/uk/ac/ox/oucs/vle/email/RejectedApprovedEmailRule.java
+++ b/impl/src/main/java/uk/ac/ox/oucs/vle/email/RejectedApprovedEmailRule.java
@@ -1,0 +1,27 @@
+package uk.ac.ox.oucs.vle.email;
+
+import uk.ac.ox.oucs.vle.CourseSignupService;
+import uk.ac.ox.oucs.vle.CourseSignupService.Status;
+
+import static uk.ac.ox.oucs.vle.CourseSignupService.Status.APPROVED;
+import static uk.ac.ox.oucs.vle.CourseSignupService.Status.REJECTED;
+
+/**
+ * Created by buckett on 02/10/15.
+ */
+public class RejectedApprovedEmailRule extends EmailRule {
+    @Override
+    public boolean matches(StateChange stateChange) {
+        return Status.matches(stateChange.getOldStatus(), APPROVED) &&
+                Status.matches(stateChange.getSignup().getStatus(), REJECTED);
+    }
+
+    @Override
+    public void perform(StateChange stateChange) {
+        service.sendStudentSignupEmail(
+                stateChange.getSignup(),
+                "reject-approver.student.subject",
+                "reject-approver.student.body",
+                new Object[] {proxy.getCurrentUser().getDisplayName(), proxy.getMyUrl(stateChange.getPlacement())});
+    }
+}

--- a/impl/src/main/java/uk/ac/ox/oucs/vle/email/RejectedEmailRule.java
+++ b/impl/src/main/java/uk/ac/ox/oucs/vle/email/RejectedEmailRule.java
@@ -1,0 +1,32 @@
+package uk.ac.ox.oucs.vle.email;
+
+import uk.ac.ox.oucs.vle.CourseSignupService;
+import uk.ac.ox.oucs.vle.CourseSignupService.Status;
+import uk.ac.ox.oucs.vle.Person;
+
+import static uk.ac.ox.oucs.vle.CourseSignupService.Status.*;
+
+/**
+ * Rule for when someone is rejected from attending a module.
+ */
+public class RejectedEmailRule extends EmailRule {
+
+    @Override
+    public boolean matches(StateChange stateChange) {
+        return Status.matches(stateChange.getOldStatus(), PENDING, WAITING) &&
+                Status.matches(stateChange.getSignup().getStatus(), REJECTED);
+    }
+
+    @Override
+    public void perform(StateChange stateChange) {
+        service.sendStudentSignupEmail(
+                stateChange.getSignup(),
+                "reject-admin.student.subject",
+                "reject-admin.student.body",
+                new Object[] {proxy.getCurrentUser().getDisplayName(), proxy.getMyUrl(stateChange.getPlacement())});
+        Person user = stateChange.getSignup().getUser();
+        service.savePlacement(user.getId(), stateChange.getPlacement());
+
+    }
+
+}

--- a/impl/src/main/java/uk/ac/ox/oucs/vle/email/StateChange.java
+++ b/impl/src/main/java/uk/ac/ox/oucs/vle/email/StateChange.java
@@ -1,0 +1,46 @@
+package uk.ac.ox.oucs.vle.email;
+
+import uk.ac.ox.oucs.vle.CourseDepartment;
+import uk.ac.ox.oucs.vle.CourseDepartmentDAO;
+import uk.ac.ox.oucs.vle.CourseSignup;
+
+import static uk.ac.ox.oucs.vle.CourseSignupService.*;
+
+/**
+ * Stores the state needed for sending out emails.
+ */
+public class StateChange {
+    public Status oldStatus;
+    public CourseSignup signup;
+    public CourseDepartment department;
+    public String placement;
+
+    public StateChange(Status oldStatus, CourseSignup signup, CourseDepartment department, String placement) {
+        this.oldStatus = oldStatus;
+        this.signup = signup;
+        this.department = department;
+        this.placement = placement;
+    }
+
+    public StateChange() {
+    }
+
+    public Status getOldStatus() {
+        return oldStatus;
+    }
+
+    public CourseSignup getSignup() {
+        return signup;
+    }
+
+    /**
+     * @return <code>null</code> or the department associated with the signup.
+     */
+    public CourseDepartment getDepartment() {
+        return department;
+    }
+
+    public String getPlacement() {
+        return placement;
+    }
+}

--- a/impl/src/main/java/uk/ac/ox/oucs/vle/email/WaitingEmailRule.java
+++ b/impl/src/main/java/uk/ac/ox/oucs/vle/email/WaitingEmailRule.java
@@ -1,0 +1,25 @@
+package uk.ac.ox.oucs.vle.email;
+
+import uk.ac.ox.oucs.vle.CourseSignupService;
+import uk.ac.ox.oucs.vle.CourseSignupService.Status;
+
+import static uk.ac.ox.oucs.vle.CourseSignupService.Status.WAITING;
+
+/**
+ * This looks all wrong and shouldn't be used as the FullEmailRule looks to do the same
+ * thing as this.
+ */
+public class WaitingEmailRule extends EmailRule {
+    @Override
+    public boolean matches(StateChange stateChange) {
+        return Status.matches(stateChange.getSignup().getStatus(), WAITING);
+    }
+
+    @Override
+    public void perform(StateChange stateChange) {
+        service.sendStudentSignupEmail(stateChange.getSignup(),
+                "withdraw.student.subject",
+                "withdraw.student.body",
+                new Object[]{proxy.getCurrentUser().getDisplayName(), proxy.getMyUrl()});
+    }
+}

--- a/impl/src/main/java/uk/ac/ox/oucs/vle/email/WithdrawnAdministratorEmailRule.java
+++ b/impl/src/main/java/uk/ac/ox/oucs/vle/email/WithdrawnAdministratorEmailRule.java
@@ -1,0 +1,35 @@
+package uk.ac.ox.oucs.vle.email;
+
+import uk.ac.ox.oucs.vle.CourseSignup;
+import uk.ac.ox.oucs.vle.CourseSignupService;
+import uk.ac.ox.oucs.vle.CourseSignupService.Status;
+import uk.ac.ox.oucs.vle.Person;
+
+import static uk.ac.ox.oucs.vle.CourseSignupService.Status.*;
+
+/**
+ * This is for when a student withdraws from a course, an email is send to all
+ * the administrators.
+ */
+public class WithdrawnAdministratorEmailRule extends EmailRule {
+    @Override
+    public boolean matches(StateChange stateChange) {
+        return Status.matches(stateChange.getOldStatus(), ACCEPTED, APPROVED, CONFIRMED)
+                && Status.matches(stateChange.getSignup().getStatus(), WITHDRAWN);
+    }
+
+    @Override
+    public void perform(StateChange stateChange) {
+        CourseSignup signup = stateChange.getSignup();
+
+        for (Person administrator : signup.getGroup().getAdministrators()) {
+            service.sendSignupEmail(
+                    administrator.getId(), signup,
+                    "withdraw.admin.subject",
+                    "withdraw.admin.body",
+                    new Object[]{proxy.getCurrentUser().getDisplayName(), proxy.getAdminUrl()});
+            service.savePlacement(administrator.getId(), proxy.getCurrentPlacementId());
+        }
+
+    }
+}

--- a/impl/src/main/java/uk/ac/ox/oucs/vle/email/WithdrawnStudentEmailRule.java
+++ b/impl/src/main/java/uk/ac/ox/oucs/vle/email/WithdrawnStudentEmailRule.java
@@ -1,0 +1,25 @@
+package uk.ac.ox.oucs.vle.email;
+
+import uk.ac.ox.oucs.vle.CourseSignupService;
+import uk.ac.ox.oucs.vle.CourseSignupService.Status;
+
+import static uk.ac.ox.oucs.vle.CourseSignupService.Status.WITHDRAWN;
+
+/**
+ * Whenever the student is withdrawn from an module email them.
+ */
+public class WithdrawnStudentEmailRule extends EmailRule {
+    @Override
+    public boolean matches(StateChange stateChange) {
+        return Status.matches(stateChange.getSignup().getStatus(), WITHDRAWN);
+    }
+
+    @Override
+    public void perform(StateChange stateChange) {
+        service.sendStudentSignupEmail(stateChange.getSignup(),
+                "withdraw.student.subject",
+                "withdraw.student.body",
+                new Object[]{proxy.getCurrentUser().getDisplayName(), proxy.getMyUrl()});
+
+    }
+}

--- a/impl/src/main/resources/course-signup-beans.xml
+++ b/impl/src/main/resources/course-signup-beans.xml
@@ -24,13 +24,14 @@
 <beans>
 
 	<bean name="uk.ac.ox.oucs.vle.CourseSignupService"
-		class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
+		class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean" singleton="true">
 		<property name="target">
 			<bean class="uk.ac.ox.oucs.vle.CourseSignupServiceImpl">
 				<property name="dao" ref="uk.ac.ox.oucs.vle.CourseDAO" />
 				<property name="proxy" ref="uk.ac.ox.oucs.vle.SakaiProxy" />
 				<property name="searchService" ref="uk.ac.ox.oucs.vle.SearchService"/>
                 <property name="nowService" ref="uk.ac.ox.oucs.vle.NowService"/>
+				<property name="emailSendingService" ref="uk.ac.ox.oucs.vle.email.EmailSendingService"/>
 			</bean>
 		</property>
 		<property name="transactionManager"
@@ -52,6 +53,12 @@
 	</bean>
 
 	<bean name="uk.ac.ox.oucs.vle.CourseDAO" class="uk.ac.ox.oucs.vle.CourseDAOImpl" >
+		<property name="sessionFactory">
+			<ref bean="org.sakaiproject.springframework.orm.hibernate.GlobalSessionFactory" />
+		</property>
+	</bean>
+
+	<bean name="uk.ac.ox.oucs.vle.UserPlacementDAO" class="uk.ac.ox.oucs.vle.UserPlacmentDAOImpl" >
 		<property name="sessionFactory">
 			<ref bean="org.sakaiproject.springframework.orm.hibernate.GlobalSessionFactory" />
 		</property>
@@ -154,6 +161,7 @@
 		<property name="target">
 			<bean class="uk.ac.ox.oucs.vle.ModuleImpl">
 				<property name="courseDao" ref="uk.ac.ox.oucs.vle.CourseDAO" />
+				<property name="placementDAO" ref="uk.ac.ox.oucs.vle.UserPlacementDAO"/>
 				<property name="proxy" ref="uk.ac.ox.oucs.vle.SakaiProxy" />
 			</bean>
 		</property>
@@ -162,6 +170,25 @@
 			<value>
 				update=PROPAGATION_REQUIRED
 			</value>
+		</property>
+	</bean>
+	<bean id="uk.ac.ox.oucs.vle.email.EmailSendingService"
+		  class="uk.ac.ox.oucs.vle.email.EmailSendingService" singleton="true" init-method="init">
+		<property name="proxy" ref="uk.ac.ox.oucs.vle.SakaiProxy"/>
+		<property name="placementDAO" ref="uk.ac.ox.oucs.vle.UserPlacementDAO"/>
+		<property name="rules">
+			<set>
+				<bean class="uk.ac.ox.oucs.vle.email.AcceptedEmailRule"/>
+				<bean class="uk.ac.ox.oucs.vle.email.ApprovedEmailRule"/>
+				<bean class="uk.ac.ox.oucs.vle.email.ConfirmedEmailRule"/>
+				<bean class="uk.ac.ox.oucs.vle.email.FullEmailRule"/>
+				<bean class="uk.ac.ox.oucs.vle.email.PendingEmailRule"/>
+				<bean class="uk.ac.ox.oucs.vle.email.RejectedAcceptedEmailRule"/>
+				<bean class="uk.ac.ox.oucs.vle.email.RejectedApprovedEmailRule"/>
+				<bean class="uk.ac.ox.oucs.vle.email.RejectedEmailRule"/>
+				<bean class="uk.ac.ox.oucs.vle.email.WithdrawnAdministratorEmailRule"/>
+				<bean class="uk.ac.ox.oucs.vle.email.WithdrawnStudentEmailRule"/>
+			</set>
 		</property>
 	</bean>
 	

--- a/impl/src/main/resources/messages.properties
+++ b/impl/src/main/resources/messages.properties
@@ -135,13 +135,13 @@ approval.supervisor.subject = [RTT] A new approval on {2} from {0}
 approval.supervisor.body = \
 {3} (who is studying for {4}) has entered you as their supervisor via the Researcher Training Tool.\n\
 \n\
-Your supervisee has requested a place on the following module::\n\
+Your supervisee has requested a place on the following course::\n\
 \n\
 {1}\n\
 \n\
 Please approve or decline this request by logging into the Researcher Training Tool (using your Web Auth ID) at <{6}>.\n\
 \n\
-It is important that you action this request at your earliest convenience so that the enrolment process can be completed, and the place on the module is allocated.\n\
+It is important that you action this request at your earliest convenience so that the enrolment process can be completed, and the place on the course is allocated.\n\
 \n\
 You can see a list of signups requiring your approval at:\n\
 <{5}>\n\
@@ -154,15 +154,15 @@ You can see a list of signups requiring your approval at:\n\
 #[3] Signed up User Display Name
 #[4] Signed up User Degree Program
 # Extra data
-#[5] URL to My Modules
+#[5] URL to My Courses
 signup.approver.subject = [RTT] A new registration on {2} from {0}
 
 signup.approver.body = \
-You are registered as the Departmental Approver for {2} module. A new sign-up has been submitted by {0} (who is studying for {4}).\n\
+You are registered as the Departmental Approver for {2} course. A new sign-up has been submitted by {0} (who is studying for {4}).\n\
 \n\
 Please approve or decline this request by logging into the Researcher Training Tool (using your Web Auth ID) at <{6}>.\n\
 \n\
-It is important that you action this request at your earliest convenience so that the enrolment process can be completed, and the place on the module is allocated.\n\
+It is important that you action this request at your earliest convenience so that the enrolment process can be completed, and the place on the course is allocated.\n\
 \n\
 You can see a list of signups requiring your approval at:\n\
 <{5}>\n\
@@ -172,17 +172,17 @@ You can see a list of signups requiring your approval at:\n\
 #[1] Component Details
 #[2] Course Title
 # Extra data
-#[3] URL to My Modules
+#[3] URL to My Courses
 confirmed.student.subject = [RTT] You have been accepted, approved and confirmed onto {2}
 confirmed.student.body = \
 Thank you for registering a place on {2}.\n\
 \n\
-Your request had been approved and you have a confirmed place on the module.\n\
+Your request had been approved and you have a confirmed place on the course.\n\
 \n\
-Please view the module page for details about the module, including dates and times of teaching and the location\n\
+Please view the course page for details about the course, including dates and times of teaching and the location\n\
 \n\
 <{1}>\n\
-If you are unable to attend the module, please withdraw in the My Modules section of the Researcher Training Tool and clicking withdraw next to the relevant module. \n\
+If you are unable to attend the course, please withdraw in the My Courses section of the Researcher Training Tool and clicking withdraw next to the relevant course. \n\
 \n\
 You can see a list of your signups at:\n\
 <{3}>\n\
@@ -193,7 +193,7 @@ You can see a list of your signups at:\n\
 #[2] Course Title
 # Extra data
 #[3] Current User
-#[4] URL to My Modules
+#[4] URL to My Courses
 reject-admin.student.subject = [RTT] You have been declined a place on {2}
 reject-admin.student.body = \
 Thank you for registering a place on {1}.\n\
@@ -232,10 +232,10 @@ You can see a list of your signups at:\n\
 #[1] Component Details
 #[2] Course Title
 # Extra data
-#[3] URL to My Modules
+#[3] URL to My Courses
 waiting.admin.subject = [RTT] A new signup is on the waiting list for {2}
 waiting.admin.body = \
-You are registered as the Module Administrator for {2} module. \n\
+You are registered as the Course Administrator for {2} course. \n\
 A new sign-up has been submitted by {3} (who is studying for {4}). \n\
 \n\
 To review signups visit the Researcher Training Tool: {5}
@@ -248,13 +248,13 @@ To review signups visit the Researcher Training Tool: {5}
 #[4] Signed up User Degree Program
 # Extra data
 #[5] Current User
-#[6] URL to My Modules
+#[6] URL to My Courses
 withdraw.admin.subject = [RTT] A withdrawl on {2} from {0}
 # {0} Signup users name, {1} the components signed up, {2} CourseGroup Title {3} Confirm URL
 withdraw.admin.body = \
-You are currently registered as a module administrator on {2}.\n\
+You are currently registered as a course administrator on {2}.\n\
 \n\
-{0} has withdrawn from this module.\n\
+{0} has withdrawn from this course.\n\
 \n\
 Please visit the Researcher Training Tool to review your signups.\n\
 <{6}>\n\
@@ -265,12 +265,12 @@ Please visit the Researcher Training Tool to review your signups.\n\
 #[2] Course Title
 # Extra data
 #[3] Current User
-#[4] URL to My Modules
+#[4] URL to My Courses
 withdraw.student.subject = [RTT] You have been withdrawn from {2}
 withdraw.student.body = \
 Thank you for withdrawing from  {1}.\n\
 \n\
-You have been removed from this module.\n\
+You have been removed from this course.\n\
 \n\
 You can see a list of your signups at:\n\
 <{4}>\n\

--- a/impl/src/test/java/uk/ac/ox/oucs/vle/CourseSignupServiceSignupSplitTest.java
+++ b/impl/src/test/java/uk/ac/ox/oucs/vle/CourseSignupServiceSignupSplitTest.java
@@ -115,7 +115,7 @@ public class CourseSignupServiceSignupSplitTest extends AbstractTestExecutionLis
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testSplitAll() {
-		// We can't leave the old signup empty of components.
+		// We can't leave the oldStatus signup empty of components.
 		Set all = new HashSet<String>();
 		all.add("compId1");
 		all.add("compId2");

--- a/impl/src/test/java/uk/ac/ox/oucs/vle/SampleDataLoader.java
+++ b/impl/src/test/java/uk/ac/ox/oucs/vle/SampleDataLoader.java
@@ -157,7 +157,7 @@ public class SampleDataLoader {
 		comp.setTermcode(term.code);
 		comp.setOpens(term.opens);
 		comp.setCloses(term.closes);
-		// We know when teaching starts so that's when we consider this old.
+		// We know when teaching starts so that's when we consider this oldStatus.
 		comp.setBaseDate(term.starts);
 		comp.setSize(size);
 		comp.setTaken(0);

--- a/impl/src/test/java/uk/ac/ox/oucs/vle/email/AcceptedEmailRuleTest.java
+++ b/impl/src/test/java/uk/ac/ox/oucs/vle/email/AcceptedEmailRuleTest.java
@@ -1,0 +1,52 @@
+package uk.ac.ox.oucs.vle.email;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.ac.ox.oucs.vle.CourseSignupService;
+import uk.ac.ox.oucs.vle.Person;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+
+/**
+ * Created by buckett on 02/10/15.
+ */
+public class AcceptedEmailRuleTest extends EmailRuleBase {
+
+    private AcceptedEmailRule rule;
+
+    @Before
+    public void setUp() {
+        rule = new AcceptedEmailRule();
+        rule.setService(emailSendingService);
+        rule.setProxy(proxy);
+    }
+
+    @Test
+    public void testMatchesPending() {
+        setOldStatus(CourseSignupService.Status.PENDING);
+        setNewStatus(CourseSignupService.Status.ACCEPTED);
+        assertTrue(rule.matches(change));
+    }
+
+    @Test
+    public void testMatchesWaiting() {
+        setOldStatus(CourseSignupService.Status.WAITING);
+        setNewStatus(CourseSignupService.Status.ACCEPTED);
+        assertTrue(rule.matches(change));
+    }
+
+    @Test
+    public void testPerform() {
+        Person supervisor = mock(Person.class);
+        when(supervisor.getId()).thenReturn("supervisor-id");
+        when(signup.getSupervisor()).thenReturn(supervisor);
+        when(signup.getId()).thenReturn("signup-id");
+        change.placement = "placement-id";
+        when(proxy.getConfirmUrl(signup.getId(), "placement-id")).thenReturn("http://server/confirm/placement-id");
+        when(proxy.getAdvanceUrl(signup.getId(), "approve", "placement-id")).thenReturn("http://server/approve/placement-id");
+        rule.perform(change);
+        verify(emailSendingService).sendSignupEmail(eq("supervisor-id"), eq(signup), anyString(), anyString(), any(Object[].class));
+    }
+
+}

--- a/impl/src/test/java/uk/ac/ox/oucs/vle/email/ApprovedEmailRuleTest.java
+++ b/impl/src/test/java/uk/ac/ox/oucs/vle/email/ApprovedEmailRuleTest.java
@@ -1,0 +1,52 @@
+package uk.ac.ox.oucs.vle.email;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.ac.ox.oucs.vle.CourseDepartment;
+import uk.ac.ox.oucs.vle.CourseSignup;
+
+import java.util.HashSet;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
+import static uk.ac.ox.oucs.vle.CourseSignupService.Status.APPROVED;
+
+/**
+ * Created by buckett on 07/10/15.
+ */
+public class ApprovedEmailRuleTest extends EmailRuleBase {
+
+    private ApprovedEmailRule rule;
+
+    @Before
+    public void setUp() {
+        rule = new ApprovedEmailRule();
+        rule.setProxy(proxy);
+        rule.setService(emailSendingService);
+    }
+
+    @Test
+    public void testMatches() {
+        setNewStatus(APPROVED);
+        assertTrue(rule.matches(change));
+    }
+
+    @Test
+    public void testPerform() {
+        CourseSignup signup = mock(CourseSignup.class);
+        when(signup.getId()).thenReturn("signup-id");
+        change.signup = signup;
+        change.placement = "placement-id";
+        CourseDepartment department = mock(CourseDepartment.class);
+        when(department.getApprovers()).thenReturn(new HashSet<String>(){{
+            add("approver-1");
+            add("approver-2");
+        }});
+        change.department = department;
+        rule.perform(change);
+        // Check both approvers get an email
+        verify(emailSendingService).sendSignupEmail(eq("approver-1"), eq(signup), anyString(), anyString(), any(Object[].class));
+        verify(emailSendingService).sendSignupEmail(eq("approver-2"), eq(signup), anyString(), anyString(), any(Object[].class));
+    }
+}

--- a/impl/src/test/java/uk/ac/ox/oucs/vle/email/ConfirmedEmailRuleTest.java
+++ b/impl/src/test/java/uk/ac/ox/oucs/vle/email/ConfirmedEmailRuleTest.java
@@ -1,0 +1,40 @@
+package uk.ac.ox.oucs.vle.email;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.verify;
+import static uk.ac.ox.oucs.vle.CourseSignupService.Status.ACCEPTED;
+import static uk.ac.ox.oucs.vle.CourseSignupService.Status.CONFIRMED;
+
+/**
+ * Created by buckett on 02/10/15.
+ */
+public class ConfirmedEmailRuleTest extends EmailRuleBase {
+
+    private ConfirmedEmailRule rule;
+
+    @Before
+    public void setUp() {
+        rule = new ConfirmedEmailRule();
+        rule.setProxy(proxy);
+        rule.setService(emailSendingService);
+    }
+
+    @Test
+    public void testMatching() {
+        setNewStatus(CONFIRMED);
+        StateChange change = new StateChange(ACCEPTED, signup, null, "placementId");
+        assertTrue(rule.matches(change));
+    }
+
+
+    @Test
+    public void testEmailOutput() {
+        StateChange change = new StateChange(ACCEPTED, signup, null, "placementId");
+        rule.perform(change);
+        verify(emailSendingService).sendStudentSignupEmail(eq(signup), anyString(), anyString(), any(Object[].class));
+    }
+}

--- a/impl/src/test/java/uk/ac/ox/oucs/vle/email/EmailRuleBase.java
+++ b/impl/src/test/java/uk/ac/ox/oucs/vle/email/EmailRuleBase.java
@@ -1,0 +1,44 @@
+package uk.ac.ox.oucs.vle.email;
+
+import org.junit.Before;
+import uk.ac.ox.oucs.vle.CourseSignup;
+import uk.ac.ox.oucs.vle.CourseSignupService;
+import uk.ac.ox.oucs.vle.SakaiProxy;
+import uk.ac.ox.oucs.vle.UserPlacementDAO;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Base test class for testing email rules.
+ */
+public class EmailRuleBase {
+
+    protected SakaiProxy proxy;
+
+    protected CourseSignup signup;
+
+    protected UserPlacementDAO placementDAO;
+
+    protected EmailSendingService emailSendingService;
+
+    protected StateChange change;
+
+    @Before
+    public final void setUpBase() {
+        proxy = mock(SakaiProxy.class);
+        signup = mock(CourseSignup.class);
+        placementDAO = mock(UserPlacementDAO.class);
+        emailSendingService = mock(EmailSendingService.class);
+        change = new StateChange();
+        change.signup = signup;
+    }
+
+    public void setNewStatus(CourseSignupService.Status status) {
+        when(signup.getStatus()).thenReturn(status);
+    }
+
+    public void setOldStatus(CourseSignupService.Status status) {
+        change.oldStatus = status;
+    }
+}

--- a/impl/src/test/java/uk/ac/ox/oucs/vle/email/FullEmailRuleTest.java
+++ b/impl/src/test/java/uk/ac/ox/oucs/vle/email/FullEmailRuleTest.java
@@ -1,0 +1,51 @@
+package uk.ac.ox.oucs.vle.email;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.ac.ox.oucs.vle.CourseGroup;
+import uk.ac.ox.oucs.vle.Person;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+import static uk.ac.ox.oucs.vle.CourseSignupService.Status.WAITING;
+
+/**
+ * Created by buckett on 07/10/15.
+ */
+public class FullEmailRuleTest extends EmailRuleBase {
+
+    private FullEmailRule rule;
+
+    @Before
+    public void setUp() {
+        rule = new FullEmailRule();
+        rule.setProxy(proxy);
+        rule.setService(emailSendingService);
+    }
+
+    @Test
+    public void testMatches() throws Exception {
+        setOldStatus(null);
+        setNewStatus(WAITING);
+        assertTrue(rule.matches(change));
+    }
+
+    @Test
+    public void testPerform() throws Exception {
+        CourseGroup group = mock(CourseGroup.class);
+        Person admin1 = mock(Person.class);
+        Person admin2 = mock(Person.class);
+        when(admin1.getId()).thenReturn("admin-1");
+        when(admin2.getId()).thenReturn("admin-2");
+        when(group.getAdministrators()).thenReturn(Arrays.asList(admin1, admin2));
+        when(signup.getGroup()).thenReturn(group);
+        rule.perform(change);
+
+        verify(emailSendingService).sendSignupWaitingEmail(eq("admin-1"), eq(signup), anyString(), anyString(), any(Object[].class));
+        verify(emailSendingService).sendSignupWaitingEmail(eq("admin-2"), eq(signup), anyString(), anyString(), any(Object[].class));
+        verify(emailSendingService).sendStudentSignupEmail(eq(signup), anyString(), anyString(), any(Object[].class));
+
+    }
+}

--- a/impl/src/test/java/uk/ac/ox/oucs/vle/email/PendingEmailRuleTest.java
+++ b/impl/src/test/java/uk/ac/ox/oucs/vle/email/PendingEmailRuleTest.java
@@ -1,0 +1,51 @@
+package uk.ac.ox.oucs.vle.email;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.ac.ox.oucs.vle.CourseGroup;
+import uk.ac.ox.oucs.vle.Person;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+import static uk.ac.ox.oucs.vle.CourseSignupService.Status.PENDING;
+
+/**
+ * Created by buckett on 07/10/15.
+ */
+public class PendingEmailRuleTest extends EmailRuleBase {
+
+    private PendingEmailRule rule;
+
+    @Before
+    public void setUp() {
+        rule = new PendingEmailRule();
+        rule.setProxy(proxy);
+        rule.setService(emailSendingService);
+
+    }
+
+    @Test
+    public void testMatches() throws Exception {
+        setOldStatus(null);
+        setNewStatus(PENDING);
+        assertTrue(rule.matches(change));
+    }
+
+    @Test
+    public void testPerform() throws Exception {
+        CourseGroup group = mock(CourseGroup.class);
+        Person admin1 = mock(Person.class);
+        Person admin2 = mock(Person.class);
+        when(admin1.getId()).thenReturn("admin-1");
+        when(admin2.getId()).thenReturn("admin-2");
+        when(group.getAdministrators()).thenReturn(Arrays.asList(admin1, admin2));
+        when(signup.getGroup()).thenReturn(group);
+
+        rule.perform(change);
+        verify(emailSendingService).sendSignupEmail(eq("admin-1"), eq(signup), anyString(), anyString(), any(Object[].class));
+        verify(emailSendingService).sendSignupEmail(eq("admin-2"), eq(signup), anyString(), anyString(), any(Object[].class));
+        verify(emailSendingService).sendStudentSignupEmail(eq(signup), anyString(), anyString(), any(Object[].class));
+    }
+}

--- a/impl/src/test/java/uk/ac/ox/oucs/vle/email/RejectedAcceptedEmailRuleTest.java
+++ b/impl/src/test/java/uk/ac/ox/oucs/vle/email/RejectedAcceptedEmailRuleTest.java
@@ -1,0 +1,61 @@
+package uk.ac.ox.oucs.vle.email;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.ac.ox.oucs.vle.Person;
+import uk.ac.ox.oucs.vle.UserProxy;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+import static uk.ac.ox.oucs.vle.CourseSignupService.Status.ACCEPTED;
+import static uk.ac.ox.oucs.vle.CourseSignupService.Status.REJECTED;
+
+/**
+ * Created by buckett on 07/10/15.
+ */
+public class RejectedAcceptedEmailRuleTest extends EmailRuleBase {
+
+    private RejectedAcceptedEmailRule rule;
+
+    @Before
+    public void setUp() {
+        rule = new RejectedAcceptedEmailRule();
+        rule.setProxy(proxy);
+        rule.setService(emailSendingService);
+    }
+
+    @Test
+    public void testMatches() throws Exception {
+        setOldStatus(ACCEPTED);
+        setNewStatus(REJECTED);
+        assertTrue(rule.matches(change));
+    }
+
+    @Test
+    public void testPerformNoSupervisor() throws Exception {
+        UserProxy current = mock(UserProxy.class);
+        when(current.getDisplayName()).thenReturn("Current User");
+        when(proxy.getCurrentUser()).thenReturn(current);
+
+        Person signupUser = mock(Person.class);
+        when (signupUser.getId()).thenReturn("signup-user-id");
+        when(signup.getUser()).thenReturn(signupUser);
+
+        rule.perform(change);
+        verify(emailSendingService).sendStudentSignupEmail(eq(signup), anyString(), anyString(), any(Object[].class));
+    }
+
+    @Test
+    public void testPerformSupervisor() throws Exception {
+        Person supervisor = mock(Person.class);
+        when(supervisor.getName()).thenReturn("Supervisor");
+        when(signup.getSupervisor()).thenReturn(supervisor);
+
+        Person signupUser = mock(Person.class);
+        when (signupUser.getId()).thenReturn("signup-user-id");
+        when(signup.getUser()).thenReturn(signupUser);
+
+        rule.perform(change);
+        verify(emailSendingService).sendStudentSignupEmail(eq(signup), anyString(), anyString(), any(Object[].class));
+    }
+}

--- a/impl/src/test/java/uk/ac/ox/oucs/vle/email/RejectedApprovedEmailRuleTest.java
+++ b/impl/src/test/java/uk/ac/ox/oucs/vle/email/RejectedApprovedEmailRuleTest.java
@@ -1,0 +1,41 @@
+package uk.ac.ox.oucs.vle.email;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.ac.ox.oucs.vle.UserProxy;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+import static uk.ac.ox.oucs.vle.CourseSignupService.Status.APPROVED;
+import static uk.ac.ox.oucs.vle.CourseSignupService.Status.REJECTED;
+
+/**
+ * Created by buckett on 07/10/15.
+ */
+public class RejectedApprovedEmailRuleTest extends EmailRuleBase {
+
+    private RejectedApprovedEmailRule rule;
+
+    @Before
+    public void setUp() {
+        rule = new RejectedApprovedEmailRule();
+        rule.setService(emailSendingService);
+        rule.setProxy(proxy);
+    }
+
+    @Test
+    public void testMatches() throws Exception {
+        setOldStatus(APPROVED);
+        setNewStatus(REJECTED);
+        assertTrue(rule.matches(change));
+    }
+
+    @Test
+    public void testPerform() throws Exception {
+        UserProxy current = mock(UserProxy.class);
+        when(current.getDisplayName()).thenReturn("Current User");
+        when(proxy.getCurrentUser()).thenReturn(current);
+        rule.perform(change);
+        verify(emailSendingService).sendStudentSignupEmail(eq(signup), anyString(), anyString(), any(Object[].class));
+    }
+}

--- a/impl/src/test/java/uk/ac/ox/oucs/vle/email/RejectedEmailRuleTest.java
+++ b/impl/src/test/java/uk/ac/ox/oucs/vle/email/RejectedEmailRuleTest.java
@@ -1,0 +1,62 @@
+package uk.ac.ox.oucs.vle.email;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.ac.ox.oucs.vle.Person;
+import uk.ac.ox.oucs.vle.UserProxy;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+import static uk.ac.ox.oucs.vle.CourseSignupService.Status.*;
+
+/**
+ * Created by buckett on 24/09/15.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class RejectedEmailRuleTest extends EmailRuleBase {
+
+    private RejectedEmailRule rule;
+
+    @Before
+    public void setUp() {
+        rule = new RejectedEmailRule();
+        rule.setService(emailSendingService);
+        rule.setProxy(proxy);
+    }
+
+    @Test
+    public void testMatchingPending() {
+        when(signup.getStatus()).thenReturn(REJECTED);
+        StateChange stateChange = new StateChange(PENDING, signup, null, "placementId");
+        assertTrue(rule.matches(stateChange));
+    }
+
+    @Test
+    public void testMatchingWaiting() {
+        when(signup.getStatus()).thenReturn(REJECTED);
+        StateChange stateChange = new StateChange(WAITING, signup, null, "placementId");
+        assertTrue(rule.matches(stateChange));
+    }
+
+    @Test
+    public void testEmailOuput() {
+        Person studentUser = mock(Person.class);
+        when(studentUser.getId()).thenReturn("student-user-1");
+        when(signup.getStatus()).thenReturn(REJECTED);
+        when(signup.getUser()).thenReturn(studentUser);
+        StateChange stateChange = new StateChange(WAITING, signup, null, "placementId");
+
+        UserProxy user = mock(UserProxy.class);
+        when(user.getDisplayName()).thenReturn("Display Name");
+        when(proxy.getCurrentUser()).thenReturn(user);
+
+        rule.perform(stateChange);
+        verify(emailSendingService).sendStudentSignupEmail(eq(signup), anyString(), anyString(), any(Object[].class));
+    }
+
+}

--- a/impl/src/test/java/uk/ac/ox/oucs/vle/email/WithdrawnAdministratorEmailRuleTest.java
+++ b/impl/src/test/java/uk/ac/ox/oucs/vle/email/WithdrawnAdministratorEmailRuleTest.java
@@ -1,0 +1,62 @@
+package uk.ac.ox.oucs.vle.email;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.ac.ox.oucs.vle.CourseGroup;
+import uk.ac.ox.oucs.vle.Person;
+import uk.ac.ox.oucs.vle.UserProxy;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+import static uk.ac.ox.oucs.vle.CourseSignupService.Status.*;
+
+/**
+ * Created by buckett on 07/10/15.
+ */
+public class WithdrawnAdministratorEmailRuleTest extends EmailRuleBase {
+
+    private WithdrawnAdministratorEmailRule rule;
+
+    @Before
+    public void setUp() {
+        rule = new WithdrawnAdministratorEmailRule();
+        rule.setProxy(proxy);
+        rule.setService(emailSendingService);
+    }
+
+    @Test
+    public void testMatches() throws Exception {
+        setNewStatus(WITHDRAWN);
+
+        setOldStatus(APPROVED);
+        assertTrue(rule.matches(change));
+
+        setOldStatus(ACCEPTED);
+        assertTrue(rule.matches(change));
+
+        setOldStatus(CONFIRMED);
+        assertTrue(rule.matches(change));
+    }
+
+    @Test
+    public void testPerform() throws Exception {
+        Person admin1 = mock(Person.class);
+        when(admin1.getId()).thenReturn("admin-1");
+        Person admin2 = mock(Person.class);
+        when(admin2.getId()).thenReturn("admin-2");
+
+        CourseGroup group = mock(CourseGroup.class);
+        when(group.getAdministrators()).thenReturn(Arrays.asList(admin1, admin2));
+        when(signup.getGroup()).thenReturn(group);
+
+        UserProxy current = mock(UserProxy.class);
+        when(current.getDisplayName()).thenReturn("Current User");
+        when(proxy.getCurrentUser()).thenReturn(current);
+
+        rule.perform(change);
+
+        verify(emailSendingService).sendSignupEmail(eq("admin-1"), eq(signup), anyString(), anyString(), any(Object[].class));
+    }
+}

--- a/impl/src/test/java/uk/ac/ox/oucs/vle/email/WithdrawnStudentEmailRuleTest.java
+++ b/impl/src/test/java/uk/ac/ox/oucs/vle/email/WithdrawnStudentEmailRuleTest.java
@@ -1,0 +1,39 @@
+package uk.ac.ox.oucs.vle.email;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.ac.ox.oucs.vle.UserProxy;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+import static uk.ac.ox.oucs.vle.CourseSignupService.Status.WITHDRAWN;
+
+/**
+ * Created by buckett on 08/10/15.
+ */
+public class WithdrawnStudentEmailRuleTest extends EmailRuleBase {
+
+    private WithdrawnStudentEmailRule rule;
+
+    @Before
+    public void setUp() {
+        rule = new WithdrawnStudentEmailRule();
+        rule.setProxy(proxy);
+        rule.setService(emailSendingService);
+    }
+
+    @Test
+    public void testMatches() throws Exception {
+        setNewStatus(WITHDRAWN);
+        assertTrue(rule.matches(change));
+    }
+
+    @Test
+    public void testPerform() throws Exception {
+        UserProxy current = mock(UserProxy.class);
+        when(current.getDisplayName()).thenReturn("Current User");
+        when(proxy.getCurrentUser()).thenReturn(current);
+        rule.perform(change);
+        verify(emailSendingService).sendStudentSignupEmail(eq(signup), anyString(), anyString(), any(Object[].class));
+    }
+}

--- a/tool/src/main/webapp/static/admin.jsp
+++ b/tool/src/main/webapp/static/admin.jsp
@@ -32,7 +32,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<title>Module Signup</title>
+<title>Course Signup</title>
 
 <link href='<c:out value="${skinRepo}" />/tool_base.css' type="text/css" rel="stylesheet" media="all" />
 <link href="<c:out value="${skinRepo}" />/<c:out value="${skinPrefix}" /><c:out value="${skinDefault}" />/tool.css" type="text/css" rel="stylesheet" media="all" />
@@ -416,7 +416,7 @@
 									if (components.length == 0) {
 										$(".errors", form)
 												.html(
-														"You need to select some modules.");
+														"You need to select some courses.");
 										return false;
 									}
 									var postSignup = function() {
@@ -712,8 +712,6 @@
 			"cache" : false,
 			"success" :
 
-			//$.getJSON("../rest/course/admin", 
-
 			function(data) {
 				var options = "";
 				courseData = data;
@@ -739,7 +737,7 @@
 
 				if (data.length > 0) {
 					$("#course-list").html(
-							'<form>Select a module: <select id="admin-course" name="course">'
+							'<form>Select a course: <select id="admin-course" name="course">'
 									+ options + '</select></form>');
 					$("#admin-course").change(function(e) {
 						var courseId = this.options[this.selectedIndex].value;
@@ -754,7 +752,7 @@
 					loadCourse(courseData[0]);
 				} else {
 					$("#course-list").html(
-							'You are not an administrator on any modules.');
+							'You are not an administrator on any courses.');
 				}
 			}
 		});
@@ -839,11 +837,11 @@
 	<div id="toolbar">
 		<ul class="navIntraTool actionToolBar">
 			<li><span><a href="home.jsp">Home</a></span></li>
-			<li><span><a href="search.jsp">Search Modules</a></span></li>
+			<li><span><a href="search.jsp">Search Courses</a></span></li>
 			<li><span><a href="index.jsp">Browse by Department</a></span></li>
 			<li><span><a href="calendar.jsp">Browse by Calendar</a></span></li>
 			<li><span><a href="vitae.jsp">Researcher Development</a></span></li>
-			<li><span><a href="my.jsp">My Modules</a></span></li>
+			<li><span><a href="my.jsp">My Courses</a></span></li>
 			<c:if test="${isPending}">
 				<li><span><a href="pending.jsp">Pending Acceptances</a></span></li>
 			</c:if>
@@ -851,7 +849,7 @@
 				<li><span><a href="approve.jsp">Pending
 							Confirmations</a></span></li>
 			</c:if>
-			<li><span>Module Administration</span></li>
+			<li><span>Course Administration</span></li>
 			<c:if test="${isLecturer}">
 				<li><span><a href="lecturer.jsp">Lecturer View</a></span></li>
 			</c:if>
@@ -917,7 +915,7 @@
 			<li>\${user.name} (\${user.email})</li>
 		{/for}
 		</ul>
-		<h2>Select Modules</h2>
+		<h2>Select Courses</h2>
 	
 		<form id="signup-add-components">
 			<span class="errors"></span>

--- a/tool/src/main/webapp/static/advance.jsp
+++ b/tool/src/main/webapp/static/advance.jsp
@@ -29,7 +29,7 @@
 <!-- Make the page render as IE8 for wrapping in jstree -->
 <meta http-equiv="X-UA-Compatible" content="IE=8">
 
-<title>Module Signup</title>
+<title>Course Signup</title>
 
 <!-- Jersey puts the model in the 'it' attribute -->
 <link href='<c:out value="${it.skinRepo}" />/tool_base.css' type="text/css" rel="stylesheet" media="all" />
@@ -45,7 +45,7 @@
 	<div id="toolbar">
 		<ul class="navIntraTool actionToolBar">
 			<li><span>Home</span></li>
-			<li><span>Search Modules</span></li>
+			<li><span>Search Courses</span></li>
 			<li><span>Browse by Department</span></li>
 			<li><span>Browse by Calendar</span></li>
 		</ul>
@@ -68,7 +68,7 @@
 								.  As the course administrator your acceptance is needed.
 							</c:when>
 						<c:when test="${it.status=='approve'}">
-								and entered you as their supervisor.  Your approval is needed for the following modules:
+								and entered you as their supervisor.  Your approval is needed for the following courses:
 							</c:when>
 						<c:when test="${it.status=='confirm'}">
 								.  As the departmental approver your acceptance is needed.

--- a/tool/src/main/webapp/static/approve.jsp
+++ b/tool/src/main/webapp/static/approve.jsp
@@ -34,7 +34,7 @@ if (UserDirectoryService.getAnonymousUser().equals(UserDirectoryService.getCurre
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<title>Module Signup</title>
+<title>Course Signup</title>
 
 <link href='<c:out value="${skinRepo}" />/tool_base.css' type="text/css" rel="stylesheet" media="all" />
 <link href="<c:out value="${skinRepo}" />/<c:out value="${skinPrefix}" /><c:out value="${skinDefault}" />/tool.css" type="text/css" rel="stylesheet" media="all" />
@@ -95,7 +95,7 @@ if (UserDirectoryService.getAnonymousUser().equals(UserDirectoryService.getCurre
 		                "sTitle": "Student",
 		                "sWidth": "20%"
 		            }, {
-		                "sTitle": "Module"
+		                "sTitle": "Course"
 		            }, {
 		                "sTitle": "Supervisor"
 		            }, {
@@ -258,17 +258,17 @@ if (UserDirectoryService.getAnonymousUser().equals(UserDirectoryService.getCurre
 	<div id="toolbar">
 		<ul class="navIntraTool actionToolBar">
 			<li><span><a href="home.jsp">Home</a></span></li>
-			<li><span><a href="search.jsp">Search Modules</a></span></li>
+			<li><span><a href="search.jsp">Search Courses</a></span></li>
 			<li><span><a href="index.jsp">Browse by Department</a></span></li>
 			<li><span><a href="calendar.jsp">Browse by Calendar</a></span></li>
 			<li><span><a href="vitae.jsp">Researcher Development</a></span></li>
-			<li><span><a href="my.jsp">My Modules</a></span></li>
+			<li><span><a href="my.jsp">My Courses</a></span></li>
 			<c:if test="${isPending}">
 				<li><span><a href="pending.jsp">Pending Acceptances</a></span></li>
 			</c:if>
 			<li><span>Pending Confirmations</span></li>
 			<c:if test="${isAdministrator}">
-				<li><span><a href="admin.jsp">Module Administration</a></span></li>
+				<li><span><a href="admin.jsp">Course Administration</a></span></li>
 			</c:if>
 			<c:if test="${isLecturer}">
 				<li><span><a href="lecturer.jsp">Lecturer View</a></span></li>
@@ -277,7 +277,7 @@ if (UserDirectoryService.getAnonymousUser().equals(UserDirectoryService.getCurre
 	</div>
 	<div>
 		<p>
-			These students have signed up for a module that needs your approval.
+			These students have signed up for a course that needs your approval.
 			<span style="float: right; margin-right: 4%;"> <input
 				type='button' class="reject-selected" value="Reject Selected"
 				name="name"></input> <input type='button' class="confirm-selected"

--- a/tool/src/main/webapp/static/calendar.jsp
+++ b/tool/src/main/webapp/static/calendar.jsp
@@ -245,12 +245,12 @@
 	<div id="toolbar">
 		<ul class="navIntraTool actionToolBar">
 			<li><span><a href="home.jsp">Home</a></span></li>
-			<li><span><a href="search.jsp">Search Modules</a></span></li>
+			<li><span><a href="search.jsp">Search Courses</a></span></li>
 			<li><span><a href="index.jsp">Browse by Department</a></span></li>
 			<li><span>Browse by Calendar</span></li>
 			<li><span><a href="vitae.jsp">Researcher Development</a></span></li>
 			<c:if test="${!externalUser}">
-				<li><span><a href="my.jsp">My Modules</a></span></li>
+				<li><span><a href="my.jsp">My Courses</a></span></li>
 				<c:if test="${isPending}">
 					<li><span><a href="pending.jsp">Pending Acceptances</a></span></li>
 				</c:if>
@@ -259,7 +259,7 @@
 								Confirmations</a></span></li>
 				</c:if>
 				<c:if test="${isAdministrator}">
-					<li><span><a href="admin.jsp">Module Administration</a></span></li>
+					<li><span><a href="admin.jsp">Course Administration</a></span></li>
 				</c:if>
 				<c:if test="${isLecturer}">
 				<li><span><a href="lecturer.jsp">Lecturer View</a></span></li>

--- a/tool/src/main/webapp/static/course.tpl
+++ b/tool/src/main/webapp/static/course.tpl
@@ -48,7 +48,7 @@
 
 					{if administrators.length > 0}
 					<tr>
-						<th>Module Administrator</th>
+						<th>Course Administrator</th>
 						<td>
 							{for administrator in administrators}
 							{if administrator.email}

--- a/tool/src/main/webapp/static/home.jsp
+++ b/tool/src/main/webapp/static/home.jsp
@@ -28,7 +28,7 @@
 	       work around is the line below --> 
 	<meta http-equiv="X-UA-Compatible" content="IE=8">
 	
-	<title>Module Search</title>
+	<title>Course Search</title>
 
 	<link href='<c:out value="${skinRepo}" />/tool_base.css' type="text/css" rel="stylesheet" media="all" />
 	<link href="<c:out value="${skinRepo}" />/<c:out value="${skinPrefix}" /><c:out value="${skinDefault}" />/tool.css" type="text/css" rel="stylesheet" media="all" />
@@ -57,12 +57,12 @@
     <ul class="navIntraTool actionToolBar">
 
 		<li><span>Home</span></li>
-		<li><span><a href="search.jsp">Search Modules</a></span></li>
+		<li><span><a href="search.jsp">Search Courses</a></span></li>
 		<li><span><a href="index.jsp">Browse by Department</a></span></li>  
 		<li><span><a href="calendar.jsp">Browse by Calendar</a></span></li>
 		<li><span><a href="vitae.jsp">Researcher Development</a></span></li>
 		<c:if test="${!externalUser}" >
-			<li><span><a href="my.jsp">My Modules</a></span></li>
+			<li><span><a href="my.jsp">My Courses</a></span></li>
 			<c:if test="${isPending}" >
 				<li><span><a href="pending.jsp">Pending Acceptances</a></span></li>	
 			</c:if>
@@ -70,7 +70,7 @@
 				<li><span><a href="approve.jsp">Pending Confirmations</a></span></li>
 			</c:if>
 			<c:if test="${isAdministrator}" >
-				<li><span><a href="admin.jsp">Module Administration</a></span></li>
+				<li><span><a href="admin.jsp">Course Administration</a></span></li>
 			</c:if>
 			<c:if test="${isLecturer}">
 				<li><span><a href="lecturer.jsp">Lecturer View</a></span></li>
@@ -92,26 +92,26 @@
 	<ul class="options" >
 
 		<li class="search" >
-			<a href="search.jsp">Search Modules</a> 
-			<span class="info">Search for modules. you can <strong>sort</strong> and <strong>filter</strong> your results by department, skill category, research methods, current/previous modules, etc.</span>
+			<a href="search.jsp">Search Courses</a>
+			<span class="info">Search for courses. you can <strong>sort</strong> and <strong>filter</strong> your results by department, skill category, research methods, current/previous courses, etc.</span>
 		</li>
 	
 		<li class="browse" >
 			<a href="index.jsp">Browse by Department</a> 
-			<span class="info">Browse for modules by division, department etc.</span>
+			<span class="info">Browse for courses by division, department etc.</span>
 		</li>
 		<li class="calendar" >
 			<a href="calendar.jsp">Browse by Calendar</a> 
-			<span class="info">Browse for modules by course start date.</span>
+			<span class="info">Browse for courses by course start date.</span>
 		</li>
 		<li class="vitae" >
 			<a href="vitae.jsp">Researcher Development</a>
-			<span class="info">Search for modules by Vitae domains.</span>
+			<span class="info">Search for courses by Vitae domains.</span>
 		</li>
 		<c:if test="${!externalUser}" >
 			<li class="myModules" >
-				<a href="my.jsp">My Modules</a> 
-				<span class="info">View modules you are currently signed up for.</span>
+				<a href="my.jsp">My Courses</a>
+				<span class="info">View courses you are currently signed up for.</span>
 			</li>
 		</c:if>
 	</ul>
@@ -128,19 +128,19 @@
 			<c:if test="${isApprover}" >
 				<li class="confirmations" >
 					<a href="approve.jsp">Pending Confirmations</a> 
-					<span class="info">View modules which are waiting for your confirmation.</span>
+					<span class="info">View courses which are waiting for your confirmation.</span>
 				</li>
 			</c:if>	
 			<c:if test="${isAdministrator}" >
 				<li class="admin">
-					<a href="admin.jsp">Module Administration</a> 
-					<span class="info">Administer modules for which you are an administrator.</span>
+					<a href="admin.jsp">Course Administration</a>
+					<span class="info">Administer courses for which you are an administrator.</span>
 				</li>
 			</c:if>
 			<c:if test="${isLecturer}" >
 				<li class="admin">
 					<a href="lecturer.jsp">Lecturers View</a> 
-					<span class="info">View modules which you are teaching.</span>
+					<span class="info">View courses which you are teaching.</span>
 				</li>
 			</c:if>
 		</c:if>

--- a/tool/src/main/webapp/static/index.jsp
+++ b/tool/src/main/webapp/static/index.jsp
@@ -249,12 +249,12 @@
 	<div id="toolbar">
 		<ul class="navIntraTool actionToolBar">
 			<li><span><a href="home.jsp">Home</a></span></li>
-			<li><span><a href="search.jsp">Search Modules</a></span></li>
+			<li><span><a href="search.jsp">Search Courses</a></span></li>
 			<li><span>Browse by Department</span></li>
 			<li><span><a href="calendar.jsp">Browse by Calendar</a></span></li>
 			<li><span><a href="vitae.jsp">Researcher Development</a></span></li>
 			<c:if test="${!externalUser}">
-				<li><span><a href="my.jsp">My Modules</a></span></li>
+				<li><span><a href="my.jsp">My Courses</a></span></li>
 				<c:if test="${isPending}">
 					<li><span><a href="pending.jsp">Pending Acceptances</a></span></li>
 				</c:if>
@@ -263,7 +263,7 @@
 								Confirmations</a></span></li>
 				</c:if>
 				<c:if test="${isAdministrator}">
-					<li><span><a href="admin.jsp">Module Administration</a></span></li>
+					<li><span><a href="admin.jsp">Course Administration</a></span></li>
 				</c:if>
 				<c:if test="${isLecturer}">
 				<li><span><a href="lecturer.jsp">Lecturer View</a></span></li>

--- a/tool/src/main/webapp/static/lecturer.jsp
+++ b/tool/src/main/webapp/static/lecturer.jsp
@@ -32,7 +32,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<title>Module Signup</title>
+<title>Course Signup</title>
 
 <link href='<c:out value="${skinRepo}" />/tool_base.css' type="text/css" rel="stylesheet" media="all" />
 <link href="<c:out value="${skinRepo}" />/<c:out value="${skinPrefix}" /><c:out value="${skinDefault}" />/tool.css" type="text/css" rel="stylesheet" media="all" />
@@ -316,7 +316,7 @@
 
 				if (data.length > 0) {
 					$("#course-list").html(
-							'<form>Select a module: <select id="admin-course" name="course">'
+							'<form>Select a course: <select id="admin-course" name="course">'
 									+ options + '</select></form>');
 					$("#admin-course").change(function(e) {
 						var courseId = this.options[this.selectedIndex].value;
@@ -331,7 +331,7 @@
 					loadCourse(courseData[0]);
 				} else {
 					$("#course-list").html(
-							'You are not an lecturer on any modules.');
+							'You are not an lecturer on any courses.');
 				}
 			}
 		});
@@ -371,11 +371,11 @@
 	<div id="toolbar">
 		<ul class="navIntraTool actionToolBar">
 			<li><span><a href="home.jsp">Home</a></span></li>
-			<li><span><a href="search.jsp">Search Modules</a></span></li>
+			<li><span><a href="search.jsp">Search Courses</a></span></li>
 			<li><span><a href="index.jsp">Browse by Department</a></span></li>
 			<li><span><a href="calendar.jsp">Browse by Calendar</a></span></li>
 			<li><span><a href="vitae.jsp">Researcher Development</a></span></li>
-			<li><span><a href="my.jsp">My Modules</a></span></li>
+			<li><span><a href="my.jsp">My Courses</a></span></li>
 			<c:if test="${isPending}">
 				<li><span><a href="pending.jsp">Pending Acceptances</a></span></li>
 			</c:if>
@@ -384,7 +384,7 @@
 							Confirmations</a></span></li>
 			</c:if>
 			<c:if test="${isAdministrator}">
-				<li><span><a href="admin.jsp">Module Administration</a></span></li>
+				<li><span><a href="admin.jsp">Course Administration</a></span></li>
 			</c:if>
 			<li><span>Lecturers View</span></li>
 		</ul>
@@ -411,7 +411,7 @@
 		<li>\${user.name} (\${user.email})</li>
 	{/for}
 	</ul>
-	<h2>Select Modules</h2>
+	<h2>Select Courses</h2>
 	
 	<form id="signup-add-components">
 	<span class="errors"></span>

--- a/tool/src/main/webapp/tools/course.signup.xml
+++ b/tool/src/main/webapp/tools/course.signup.xml
@@ -20,8 +20,8 @@
   -->
 
 <registration>
-	<tool id="course.signup" title="Module Signup"
-		description="Tool for allowing people to signup to modules.">
+	<tool id="course.signup" title="Course Signup"
+		description="Tool for allowing people to signup to courses.">
 		
 		<configuration name="default-nodes" value="root" />
 		


### PR DESCRIPTION
This also has a large refactor of email sending which extracts it out from the main service into a rule base component. This makes it easier to test, but also allows us to use it to send the correct emails for arbitrary state changes. It should also make the iCal generation easier.