### PR TITLE
WL-2979 Make sure with work on narrow displays.

### DIFF
--- a/tool/src/main/webapp/static/lib/tool.css
+++ b/tool/src/main/webapp/static/lib/tool.css
@@ -479,3 +479,15 @@ div.calendarView a.action {
     list-style-type: none;
 }
 
+/* This is to stop the search page wrapping badly on narrow setups. Main content is 70% right is 26% */
+.left {
+    padding-left: 1%;
+    padding-right: 0%;
+}
+
+.advanced_search .right {
+    padding-left: 1%;
+    padding-right: 1%;
+}
+
+

--- a/tool/src/main/webapp/static/search.jsp
+++ b/tool/src/main/webapp/static/search.jsp
@@ -43,10 +43,10 @@
   
   <link rel="stylesheet" type="text/css" href="lib/jqmodal-r14/jqModal.css" />
   <link rel="stylesheet" type="text/css" href="lib/jquery-ui-1.8.4.custom/css/smoothness/jquery-ui-1.8.4.custom.css" />
-  <link rel="stylesheet" type="text/css" href="lib/tool.css" />
+
   
 	<link rel="stylesheet" href="lib/ajax-solr-master/ajax-solr-bundle.min.css">
-
+	<link rel="stylesheet" type="text/css" href="lib/tool.css" />
 	<script src="lib/ajax-solr-master/search.js"></script>
 	
 	<script src="lib/ajax-solr-master/ajax-solr-bundle.min.js"></script>


### PR DESCRIPTION
The problem was that as the window became narrower the padding on the elements became more than 3% of the width and this caused the content to wrap around.
Making all the horizontal padding percentages fixed it.

The CSS order change was so that we can override the standard styles.