### PR TITLE
WL-2881 Make all REST request un-cached.

### DIFF
--- a/tool/src/main/java/uk/ac/ox/oucs/vle/resources/CacheResponseFilter.java
+++ b/tool/src/main/java/uk/ac/ox/oucs/vle/resources/CacheResponseFilter.java
@@ -1,0 +1,23 @@
+package uk.ac.ox.oucs.vle.resources;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.CacheControl;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+
+/**
+ * Sets sensible caching headers.
+ */
+@Provider
+public class CacheResponseFilter implements ContainerResponseFilter {
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
+        String cacheHeader = responseContext.getHeaderString("Cache-Control");
+        if (cacheHeader == null) {
+            responseContext.getHeaders().add("Cache-Control", "no-cache");
+        }
+
+    }
+}

--- a/tool/src/test/java/uk/ac/ox/oucs/vle/CacheResponseFilterTest.java
+++ b/tool/src/test/java/uk/ac/ox/oucs/vle/CacheResponseFilterTest.java
@@ -1,0 +1,23 @@
+package uk.ac.ox.oucs.vle;
+
+import org.junit.Test;
+
+import javax.ws.rs.core.Response;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Check that we're setting a good character set on our responses. All the REST services shouldn't be cached by
+ * the client as they may have changed.
+ */
+public class CacheResponseFilterTest extends ResourceTest {
+
+    @Test
+    public void testCacheHeader() {
+        // Needs to be a URL that generates a response
+        Response response = target("/signup/my").request("application/json").get();
+        String header = response.getHeaderString("Cache-Control");
+        assertTrue(header.contains("no-cache"));
+    }
+}
+

--- a/tool/src/test/java/uk/ac/ox/oucs/vle/CharsetResponseFilterTest.java
+++ b/tool/src/test/java/uk/ac/ox/oucs/vle/CharsetResponseFilterTest.java
@@ -1,6 +1,5 @@
 package uk.ac.ox.oucs.vle;
 
-import org.glassfish.jersey.test.spi.TestContainerFactory;
 import org.junit.Test;
 
 import javax.ws.rs.core.Response;


### PR DESCRIPTION
IE was caching some REST requests (we didn’t say they weren’t) so using old data. We now say that all the JSON data returned in uncacheable so it has to be re-retrieved each time. The means that when a signup is added by an administrator the top table of the administration page is also updated with the new data.