### PR TITLE
WL-4168 Don’t fail when there is no presenter.

### DIFF
--- a/tool/src/main/java/uk/ac/ox/oucs/vle/resources/PDFWriter.java
+++ b/tool/src/main/java/uk/ac/ox/oucs/vle/resources/PDFWriter.java
@@ -101,7 +101,8 @@ public class PDFWriter {
 
 			// Presenter
 			paragraph = new Paragraph();
-			phrase = new Phrase("\nPresenter: " + courseComponent.getPresenter().getName(), authorFont);
+			Person presenter = courseComponent.getPresenter();
+			phrase = new Phrase("\nPresenter: " + ((presenter == null)?"":presenter.getName()), authorFont);
 			paragraph.add(phrase);
 			paragraph.setIndentationLeft(25);
 			paragraph.setIndentationRight(25);


### PR DESCRIPTION
Some courses now don’t have a presenter in the database, this would cause a NPE when exporting the register.