### PR TITLE
WL-4029 Allow exceptions of text/xml resources to work.

### DIFF
--- a/tool/src/main/java/uk/ac/ox/oucs/vle/resources/CustomExceptionMapper.java
+++ b/tool/src/main/java/uk/ac/ox/oucs/vle/resources/CustomExceptionMapper.java
@@ -27,7 +27,10 @@ import uk.ac.ox.oucs.vle.PermissionDeniedException;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
@@ -48,16 +51,16 @@ public class CustomExceptionMapper implements ExceptionMapper<CourseSignupExcept
 	private static final FailureMessage notFound = new FailureMessage("The requested resource was not found");
 
 	public Response toResponse(CourseSignupException exception) {
+		ResponseBuilder builder;
 		if(exception instanceof NotFoundException) {
-			return Response.status(Status.NOT_FOUND)
-					.entity(notFound)
-					.build();
+			builder = Response.status(Status.NOT_FOUND).entity(notFound);
 		} else if (exception instanceof PermissionDeniedException) {
-			return Response.status(Status.FORBIDDEN)
-					.entity(forbiddenMap)
-					.build();
+			builder = Response.status(Status.FORBIDDEN).entity(forbiddenMap);
+		} else {
+			builder = Response.status(Status.INTERNAL_SERVER_ERROR).entity(exception.getMessage());
 		}
-		return Response.status(Status.INTERNAL_SERVER_ERROR).entity(exception.getMessage()).build();
+		// We force all exceptions to be JSON as we don't have MessageBodyWriters for anything else.
+		return builder.type(MediaType.APPLICATION_JSON_TYPE).build();
 	}
 
 }

--- a/tool/src/test/java/uk/ac/ox/oucs/vle/SignupResourceTest.java
+++ b/tool/src/test/java/uk/ac/ox/oucs/vle/SignupResourceTest.java
@@ -65,4 +65,21 @@ public class SignupResourceTest extends ResourceTest {
         Response response = target("/signup/my").request("application/json").get();
         assertEquals(200, response.getStatus());
     }
+
+    @Test
+    public void testNotAllowedExportError() {
+        // Check that when you're not allowed to export we generate a good message.
+        when(courseSignupService.getAllComponents()).thenThrow(PermissionDeniedException.class);
+        when(proxy.isAnonymousUser()).thenReturn(false);
+        Response response = target("/signup/component/2014/all.xml").queryParam("_auth", "basic").request().get();
+        assertEquals(403, response.getStatus());
+    }
+
+    @Test
+    public void testNotAllowedExportAnonError() {
+        // Check that when you're not logged in we give a good error.
+        when(proxy.isAnonymousUser()).thenReturn(true);
+        Response response = target("/signup/component/2014/all.xml").queryParam("_auth", "basic").request().get();
+        assertEquals(403, response.getStatus());
+    }
 }


### PR DESCRIPTION
When we were mapping the exceptions onto responses we didn’t specify a type and it was attempting to map them to the requested response type (text/xml), as we have no MessageBodyWriters for this type it would fail. As we only have MessageBodyWriters for application/json we force all mapped exceptions to be of this type.