### PR TITLE
WL-4279 Correctly get the URL in email message.

### DIFF
--- a/impl/src/main/resources/messages.properties
+++ b/impl/src/main/resources/messages.properties
@@ -119,7 +119,7 @@ You have been added to the waiting list for the following module(s):\n\
 You will be advised should a place become available.\n\
 \n\
 Please visit the Researcher Training Tool service to review this signup.\n\
-<{4}>\n\
+<{3}>\n\
 
 #Supervisor Approver Messages
 #Signup data (sendSignupEmail)


### PR DESCRIPTION
When sending our an email message to a student saying that the course is full we were putting the wrong parameter into it which wasn’t getting replaced.